### PR TITLE
Inventory&contains sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
 
       - name: Setup Gradle
@@ -42,10 +42,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+### SpectatorPlus ###
+fabric/sources

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,17 @@
+# Minecraft 26.1 Source Code
+
+This repository contains an extracted copy of the decompiled Minecraft 26.1 source code under `fabric/sources/26.1/`.
+
+## What is this?
+When updating mods to newer versions of Minecraft (e.g., migrating to 26.1), the method signatures, fields, and class hierarchies in the underlying game code frequently change. This directory acts as a local, fully searchable repository of the vanilla Minecraft codebase (both common and client-side logic).
+
+## How to use it
+As an AI Agent or developer, you can use these sources to investigate API changes and resolve compilation errors.
+
+**Best Practices for Agents:**
+1. **Search for references:** If you encounter an `InvalidInjectionException` or a `NoSuchMethodError`, use the `grep_search` tool within `fabric/sources/26.1/` to find the target class and see how the method signature has changed.
+   * Example: `grep_search(SearchPath="fabric/sources/26.1", Query="slotClicked", MatchPerLine=true)`
+2. **Examine classes:** Once you find the target file, use the `view_file` tool to inspect the exact parameters, fields, and implementations to properly configure your Mixins or API calls.
+3. **Trace logic:** You can trace how vanilla Minecraft implements specific mechanics by searching interfaces or base classes within this directory to understand the intended usage in the current version.
+
+*Note: The `fabric/sources/` directory is ignored by Git to prevent bloating the system repository.*

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,12 +1,11 @@
 plugins {
-    id("fabric-loom") version "1.14-SNAPSHOT"
+    id("net.fabricmc.fabric-loom-no-remap") version "1.14.0-alpha.31"
     id("spectatorplus.platform")
 }
 
 description = "A Fabric mod that improves spectator mode by showing the hotbar, health, and held item of the spectated player"
 
 repositories {
-    maven("https://maven.parchmentmc.org")
     maven("https://oss.sonatype.org/content/repositories/snapshots")
     maven("https://maven.shedaniel.me/")
     maven("https://maven.terraformersmc.com/releases/")
@@ -41,20 +40,17 @@ loom {
 
 dependencies {
     minecraft("com.mojang:minecraft:${property("minecraft_version")}")
-    modImplementation("net.fabricmc:fabric-loader:${property("loader_version")}")
-    mappings(loom.layered {
-        officialMojangMappings()
-        parchment("org.parchmentmc.data:parchment-${property("parchment_minecraft_version")}:${property("parchment_version")}@zip")
-    })
-    modImplementation("net.fabricmc.fabric-api:fabric-api:${property("fabric_version")}")
+    implementation("net.fabricmc:fabric-loader:${property("loader_version")}")
+    // MC 26.1 is unobfuscated — no mappings needed
+    implementation("net.fabricmc.fabric-api:fabric-api:${property("fabric_version")}")
 
-    include(modImplementation("me.lucko:fabric-permissions-api:${property("fabric_permissions_api_version")}")!!)
+    include(implementation("me.lucko:fabric-permissions-api:${property("fabric_permissions_api_version")}")!!)
 
-    modImplementation("me.shedaniel.cloth:cloth-config-fabric:${property("cloth_config_version")}") {
+    implementation("me.shedaniel.cloth:cloth-config-fabric:${property("cloth_config_version")}") {
         exclude("net.fabricmc.fabric-api")
     }
 
-    modImplementation("com.terraformersmc:modmenu:${property("modmenu_version")}")
+    implementation("com.terraformersmc:modmenu:${property("modmenu_version")}")
 }
 
 tasks {
@@ -74,7 +70,5 @@ tasks {
         from("../LICENSE")
     }
 
-    remapJar {
-        archiveVersion = getByName<Jar>("jar").archiveVersion
-    }
+
 }

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("net.fabricmc.fabric-loom-no-remap") version "1.14.0-alpha.31"
+    id("net.fabricmc.fabric-loom") version "1.15.5"
     id("spectatorplus.platform")
 }
 
@@ -41,16 +41,20 @@ loom {
 dependencies {
     minecraft("com.mojang:minecraft:${property("minecraft_version")}")
     implementation("net.fabricmc:fabric-loader:${property("loader_version")}")
-    // MC 26.1 is unobfuscated — no mappings needed
+
+    // Fabric API
     implementation("net.fabricmc.fabric-api:fabric-api:${property("fabric_version")}")
 
     include(implementation("me.lucko:fabric-permissions-api:${property("fabric_permissions_api_version")}")!!)
 
     implementation("me.shedaniel.cloth:cloth-config-fabric:${property("cloth_config_version")}") {
-        exclude("net.fabricmc.fabric-api")
+        exclude(group = "net.fabricmc.fabric-api")
     }
 
     implementation("com.terraformersmc:modmenu:${property("modmenu_version")}")
+
+    include(implementation("io.github.llamalad7:mixinextras-fabric:${property("mixinextras_version")}")!!)
+    annotationProcessor("io.github.llamalad7:mixinextras-fabric:${property("mixinextras_version")}")
 }
 
 tasks {

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,13 +1,9 @@
-minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.3
+minecraft_version=26.1-snapshot-9
 loader_version=0.18.4
 
 # Fabric API
-fabric_version=0.140.2+1.21.11
-
-parchment_minecraft_version=1.21.11
-parchment_version=2025.12.20
+fabric_version=0.143.5+26.1
 
 fabric_permissions_api_version=0.6.1
-cloth_config_version=21.11.153
-modmenu_version=17.0.0-beta.1
+cloth_config_version=26.1.160
+modmenu_version=18.0.0-alpha.5

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,9 +1,10 @@
-minecraft_version=26.1-snapshot-9
-loader_version=0.18.4
+minecraft_version=26.1
+loader_version=0.18.5
 
 # Fabric API
-fabric_version=0.143.5+26.1
+fabric_version=0.144.4+26.1
 
-fabric_permissions_api_version=0.6.1
-cloth_config_version=26.1.160
-modmenu_version=18.0.0-alpha.5
+fabric_permissions_api_version=0.7.0
+cloth_config_version=26.1.154
+modmenu_version=18.0.0-alpha.8
+mixinextras_version=0.5.3

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/SpectatorKeybinds.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/SpectatorKeybinds.java
@@ -5,7 +5,7 @@ import com.hpfxd.spectatorplus.fabric.client.mixin.PlayerMenuItemAccessor;
 import com.hpfxd.spectatorplus.fabric.client.mixin.SpectatorGuiAccessor;
 import com.hpfxd.spectatorplus.fabric.client.mixin.SpectatorMenuAccessor;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
-import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.util.Util;
 import net.minecraft.client.KeyMapping;
@@ -37,19 +37,19 @@ public class SpectatorKeybinds {
     private static UUID targetCursorId;
 
     public static void init() {
-        CLOSEST_PLAYER = KeyBindingHelper.registerKeyBinding(new KeyMapping(
+        CLOSEST_PLAYER = KeyMappingHelper.registerKeyMapping(new KeyMapping(
                 "key.spectatorplus.closestPlayer",
                 GLFW.GLFW_KEY_UP,
                 KeyMapping.Category.MISC
         ));
 
-        NEXT_PLAYER = KeyBindingHelper.registerKeyBinding(new KeyMapping(
+        NEXT_PLAYER = KeyMappingHelper.registerKeyMapping(new KeyMapping(
                 "key.spectatorplus.nextPlayer",
                 GLFW.GLFW_KEY_RIGHT,
                 KeyMapping.Category.MISC
         ));
 
-        PREVIOUS_PLAYER = KeyBindingHelper.registerKeyBinding(new KeyMapping(
+        PREVIOUS_PLAYER = KeyMappingHelper.registerKeyMapping(new KeyMapping(
                 "key.spectatorplus.previousPlayer",
                 GLFW.GLFW_KEY_LEFT,
                 KeyMapping.Category.MISC
@@ -65,10 +65,10 @@ public class SpectatorKeybinds {
 
                 if (nearest != null) {
                     setTarget(mc, nearest.getUUID());
-                    mc.player.displayClientMessage(Component.translatable("spectatorplus.target.now-spectating", Component.empty().append(nearest.getDisplayName())
-                            .withStyle(ChatFormatting.WHITE)).withStyle(ChatFormatting.GRAY), true);
+                    mc.player.sendOverlayMessage(Component.translatable("spectatorplus.target.now-spectating", Component.empty().append(nearest.getDisplayName())
+                            .withStyle(ChatFormatting.WHITE)).withStyle(ChatFormatting.GRAY));
                 } else {
-                    mc.player.displayClientMessage(Component.translatable("spectatorplus.target.no-closest-player").withStyle(ChatFormatting.RED), true);
+                    mc.player.sendOverlayMessage(Component.translatable("spectatorplus.target.no-closest-player").withStyle(ChatFormatting.RED));
                 }
             }
 
@@ -87,10 +87,10 @@ public class SpectatorKeybinds {
 
         if (target != null && !target.getProfile().id().equals(mc.getCameraEntity().getUUID())) {
             setTarget(mc, target.getProfile().id());
-            mc.player.displayClientMessage(Component.translatable("spectatorplus.target.now-spectating", Component.empty().append(mc.gui.getTabList().getNameForDisplay(target))
-                    .withStyle(ChatFormatting.WHITE)).withStyle(ChatFormatting.GRAY), true);
+            mc.player.sendOverlayMessage(Component.translatable("spectatorplus.target.now-spectating", Component.empty().append(mc.gui.getTabList().getNameForDisplay(target))
+                    .withStyle(ChatFormatting.WHITE)).withStyle(ChatFormatting.GRAY));
         } else {
-            mc.player.displayClientMessage(Component.translatable("spectatorplus.target.no-player").withStyle(ChatFormatting.RED), true);
+            mc.player.sendOverlayMessage(Component.translatable("spectatorplus.target.no-player").withStyle(ChatFormatting.RED));
         }
     }
 

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/gui/screens/DummyContainer.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/gui/screens/DummyContainer.java
@@ -1,29 +1,38 @@
 package com.hpfxd.spectatorplus.fabric.client.gui.screens;
 
+import net.minecraft.core.NonNullList;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 public class DummyContainer implements Container {
-    private final int size;
+    private final NonNullList<ItemStack> items;
 
     public DummyContainer(int size) {
-        this.size = size;
+        this.items = NonNullList.withSize(size, ItemStack.EMPTY);
     }
 
     @Override
     public int getContainerSize() {
-        return this.size;
+        return this.items.size();
     }
 
     @Override
     public boolean isEmpty() {
+        for (ItemStack item : this.items) {
+            if (!item.isEmpty()) {
+                return false;
+            }
+        }
         return true;
     }
 
     @Override
     public @NotNull ItemStack getItem(int slot) {
+        if (slot >= 0 && slot < this.items.size()) {
+            return this.items.get(slot);
+        }
         return ItemStack.EMPTY;
     }
 
@@ -39,6 +48,9 @@ public class DummyContainer implements Container {
 
     @Override
     public void setItem(int slot, ItemStack stack) {
+        if (slot >= 0 && slot < this.items.size()) {
+            this.items.set(slot, stack);
+        }
     }
 
     @Override
@@ -52,5 +64,6 @@ public class DummyContainer implements Container {
 
     @Override
     public void clearContent() {
+        this.items.clear();
     }
 }

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/gui/screens/SyncedInventoryScreen.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/gui/screens/SyncedInventoryScreen.java
@@ -1,8 +1,8 @@
 package com.hpfxd.spectatorplus.fabric.client.gui.screens;
 
-import com.hpfxd.spectatorplus.fabric.client.mixin.InventoryAccessor;
 import com.hpfxd.spectatorplus.fabric.client.mixin.screen.AbstractRecipeBookScreenAccessor;
 import com.hpfxd.spectatorplus.fabric.client.mixin.screen.ImageButtonAccessor;
+import com.hpfxd.spectatorplus.fabric.client.sync.ClientSyncController;
 import net.minecraft.client.gui.components.ImageButton;
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.components.WidgetSprites;
@@ -10,7 +10,6 @@ import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.narration.NarratableEntry;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.client.gui.screens.recipebook.RecipeBookComponent;
-import net.minecraft.world.entity.EntityEquipment;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 
@@ -33,15 +32,17 @@ public class SyncedInventoryScreen extends InventoryScreen {
     }
 
     private void syncOtherItems() {
-        final SyncedInventoryMenu menu = (SyncedInventoryMenu) this.menu;
-        final Inventory fakeInventory = menu.getInventory();
+        // If the mixin worked correctly, this.menu should be a SyncedInventoryMenu
+        if (this.menu instanceof SyncedInventoryMenu syncedMenu) {
+            final Inventory inventory = syncedMenu.getInventory();
 
-        // Use synced inventory data for all slots (main, armor, offhand)
-        var syncData = com.hpfxd.spectatorplus.fabric.client.sync.ClientSyncController.syncData;
-        if (syncData != null && syncData.screen != null && syncData.screen.inventoryItems != null) {
-            var items = syncData.screen.inventoryItems;
-            for (int i = 0; i < items.size(); i++) {
-                fakeInventory.setItem(i, items.get(i));
+            // Use synced inventory data for all slots (main, armor, offhand)
+            var syncData = ClientSyncController.syncData;
+            if (syncData != null && syncData.screen != null && syncData.screen.inventoryItems != null) {
+                var items = syncData.screen.inventoryItems;
+                for (int i = 0; i < items.size() && i < 41; i++) {
+                    inventory.setItem(i, items.get(i));
+                }
             }
         }
     }

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/ExperienceBarRendererMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/ExperienceBarRendererMixin.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 public class ExperienceBarRendererMixin {
     @Shadow @Final private Minecraft minecraft;
 
-    @Redirect(method = "renderBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getXpNeededForNextLevel()I"))
+    @Redirect(method = "extractBackground", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getXpNeededForNextLevel()I"))
     private int spectatorplus$showSyncedExperienceBar(LocalPlayer instance) {
         if (ClientSyncController.syncData != null && ClientSyncController.syncData.experienceLevel != -1 && SpecUtil.getCameraPlayer(this.minecraft) != null) {
             // If experienceNeededForNextLevel is 0, return 1 to ensure the bar renders
@@ -26,7 +26,7 @@ public class ExperienceBarRendererMixin {
         return instance.getXpNeededForNextLevel();
     }
 
-    @Redirect(method = "renderBackground", at = @At(value = "FIELD", target = "Lnet/minecraft/client/player/LocalPlayer;experienceProgress:F", opcode = Opcodes.GETFIELD))
+    @Redirect(method = "extractBackground", at = @At(value = "FIELD", target = "Lnet/minecraft/client/player/LocalPlayer;experienceProgress:F", opcode = Opcodes.GETFIELD))
     private float spectatorplus$showSyncedExperienceProgress(LocalPlayer instance) {
         if (ClientSyncController.syncData != null && ClientSyncController.syncData.experienceLevel != -1 && SpecUtil.getCameraPlayer(this.minecraft) != null) {
             return ClientSyncController.syncData.experienceProgress;

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/GameRendererMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/GameRendererMixin.java
@@ -37,9 +37,6 @@ public abstract class GameRendererMixin {
     private Minecraft minecraft;
     @Shadow
     @Final
-    private LightTexture lightTexture;
-    @Shadow
-    @Final
     private RenderBuffers renderBuffers;
     @Shadow
     @Final

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/GameRendererMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/GameRendererMixin.java
@@ -8,9 +8,9 @@ import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.entity.ClientAvatarState;
 import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.client.renderer.*;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.core.Direction;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
@@ -18,7 +18,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.phys.Vec3;
-import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -26,7 +25,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GameRenderer.class)
@@ -77,7 +75,7 @@ public abstract class GameRendererMixin {
     // }
 
     @Inject(method = "renderItemInHand", at = @At(value = "INVOKE", target = "Lorg/joml/Matrix4fStack;popMatrix()Lorg/joml/Matrix4fStack;", remap = false))
-    public void spectatorplus$renderItemInHand(float partialTicks, boolean sleeping, Matrix4f projectionMatrix,
+    public void spectatorplus$renderItemInHand(CameraRenderState cameraState, float partialTicks, Matrix4fc projectionMatrix,
             CallbackInfo ci, @Local PoseStack poseStackIn) {
         if (SpectatorClientMod.config.renderArms && this.minecraft.player != null
                 && this.minecraft.options.getCameraType().isFirstPerson() && !this.minecraft.options.hideGui) {
@@ -198,18 +196,18 @@ public abstract class GameRendererMixin {
         }
     }
 
-    @Redirect(method = "bobView", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/entity/ClientAvatarState;getBackwardsInterpolatedWalkDistance(F)F"))
-    float spectatorplus$modifyBobWalkDist(ClientAvatarState instance, float partialTick) {
+    @ModifyExpressionValue(method = "bobView", at = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/state/level/CameraEntityRenderState;backwardsInterpolatedWalkDistance:F"))
+    float spectatorplus$modifyBobWalkDist(float original) {
         if (minecraft.getCameraEntity() == this.minecraft.player)
-            return instance.getBackwardsInterpolatedWalkDistance(partialTick);
+            return original;
         float f = this.walkDist - this.walkDistO;
-        return -(this.walkDist + f * partialTick);
+        return -(this.walkDist + f);
     }
 
-    @Redirect(method = "bobView", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/entity/ClientAvatarState;getInterpolatedBob(F)F"))
-    float spectatorplus$modifyBobValue(ClientAvatarState instance, float partialTick) {
+    @ModifyExpressionValue(method = "bobView", at = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/state/level/CameraEntityRenderState;bob:F"))
+    float spectatorplus$modifyBobValue(float original) {
         if (minecraft.getCameraEntity() == this.minecraft.player)
-            return instance.getInterpolatedBob(partialTick);
-        return Mth.lerp(partialTick, this.bobO, this.bob);
+            return original;
+        return Mth.lerp(1.0F, this.bobO, this.bob);
     }
 }

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/GuiMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/GuiMixin.java
@@ -53,9 +53,10 @@ public abstract class GuiMixin {
     @Shadow
     public abstract SpectatorGui getSpectatorGui();
 
-    protected abstract void renderItemHotbar(GuiGraphicsExtractor guiGraphics, DeltaTracker deltaTracker);
+    @Shadow
+    protected abstract void extractItemHotbar(GuiGraphicsExtractor guiGraphicsExtractor, DeltaTracker deltaTracker);
 
-    protected abstract void renderPortalOverlay(GuiGraphicsExtractor guiGraphics, float intensity);
+
 
     @Shadow
     @Final
@@ -121,7 +122,7 @@ public abstract class GuiMixin {
         return instance.getPercentFrozen();
     }
 
-    @Inject(method = "extractHotbarAndDecorations(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/components/spectator/SpectatorGui;renderHotbar(Lnet/minecraft/client/gui/GuiGraphicsExtractor;)V"))
+    @Inject(method = "extractHotbarAndDecorations(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/components/spectator/SpectatorGui;extractHotbar(Lnet/minecraft/client/gui/GuiGraphicsExtractor;)V"))
     private void spectatorplus$renderHotbar(GuiGraphicsExtractor guiGraphics, DeltaTracker deltaTracker, CallbackInfo ci,
             @Share("spectated") LocalRef<AbstractClientPlayer> spectatedRef) {
         if (!this.getSpectatorGui().isMenuActive() && !this.minecraft.options.hideGui) {
@@ -131,7 +132,7 @@ public abstract class GuiMixin {
             if (spectated != null) {
                 if (ClientSyncController.syncData != null && ClientSyncController.syncData.selectedHotbarSlot != -1
                         && !spectated.isSpectator() && SpectatorClientMod.config.renderHotbar) {
-                    this.renderItemHotbar(guiGraphics, deltaTracker);
+                    this.extractItemHotbar(guiGraphics, deltaTracker);
                 }
 
                 // Render all spectatee's armor in the top right: helmet, chestplate, leggings,

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/GuiMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/GuiMixin.java
@@ -13,7 +13,7 @@ import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.spectator.SpectatorGui;
 import net.minecraft.client.multiplayer.MultiPlayerGameMode;
 import net.minecraft.client.player.AbstractClientPlayer;
@@ -53,11 +53,9 @@ public abstract class GuiMixin {
     @Shadow
     public abstract SpectatorGui getSpectatorGui();
 
-    @Shadow
-    protected abstract void renderItemHotbar(GuiGraphics guiGraphics, DeltaTracker deltaTracker);
+    protected abstract void renderItemHotbar(GuiGraphicsExtractor guiGraphics, DeltaTracker deltaTracker);
 
-    @Shadow
-    protected abstract void renderPortalOverlay(GuiGraphics guiGraphics, float intensity);
+    protected abstract void renderPortalOverlay(GuiGraphicsExtractor guiGraphics, float intensity);
 
     @Shadow
     @Final
@@ -78,8 +76,8 @@ public abstract class GuiMixin {
             EMPTY_ARMOR_SLOT_BOOTS, EMPTY_ARMOR_SLOT_LEGGINGS, EMPTY_ARMOR_SLOT_CHESTPLATE, EMPTY_ARMOR_SLOT_HELMET
     };
 
-    @Inject(method = "renderEffects(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", at = @At("HEAD"), cancellable = true)
-    private void spectatorplus$cancelRenderEffects(GuiGraphics guiGraphics, DeltaTracker deltaTracker,
+    @Inject(method = "extractEffects(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V", at = @At("HEAD"), cancellable = true)
+    private void spectatorplus$cancelRenderEffects(GuiGraphicsExtractor guiGraphics, DeltaTracker deltaTracker,
             CallbackInfo ci) {
         final AbstractClientPlayer spectated = SpecUtil.getCameraPlayer(this.minecraft);
         if (spectated != null) {
@@ -87,7 +85,7 @@ public abstract class GuiMixin {
         }
     }
 
-    @Redirect(method = "renderCameraOverlays(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;isScoping()Z"))
+    @Redirect(method = "extractCameraOverlays(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;isScoping()Z"))
     private boolean spectatorplus$renderScoping(LocalPlayer instance) {
         final AbstractClientPlayer spectated = SpecUtil.getCameraPlayer(this.minecraft);
         if (spectated != null) {
@@ -96,7 +94,7 @@ public abstract class GuiMixin {
         return instance.isScoping();
     }
 
-    @Redirect(method = "renderCameraOverlays(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getItemBySlot(Lnet/minecraft/world/entity/EquipmentSlot;)Lnet/minecraft/world/item/ItemStack;"))
+    @Redirect(method = "extractCameraOverlays(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getItemBySlot(Lnet/minecraft/world/entity/EquipmentSlot;)Lnet/minecraft/world/item/ItemStack;"))
     private ItemStack spectatorplus$renderItemCameraOverlay(LocalPlayer instance, EquipmentSlot slot) {
         final AbstractClientPlayer spectated = SpecUtil.getCameraPlayer(this.minecraft);
         if (spectated != null) {
@@ -105,7 +103,7 @@ public abstract class GuiMixin {
         return instance.getItemBySlot(slot);
     }
 
-    @Redirect(method = "renderCameraOverlays(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getTicksFrozen()I"))
+    @Redirect(method = "extractCameraOverlays(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getTicksFrozen()I"))
     private int spectatorplus$renderFreezeOverlay(LocalPlayer instance) {
         final AbstractClientPlayer spectated = SpecUtil.getCameraPlayer(this.minecraft);
         if (spectated != null) {
@@ -114,7 +112,7 @@ public abstract class GuiMixin {
         return instance.getTicksFrozen();
     }
 
-    @Redirect(method = "renderCameraOverlays(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getPercentFrozen()F"))
+    @Redirect(method = "extractCameraOverlays(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getPercentFrozen()F"))
     private float spectatorplus$renderFreezeOverlayPercent(LocalPlayer instance) {
         final AbstractClientPlayer spectated = SpecUtil.getCameraPlayer(this.minecraft);
         if (spectated != null) {
@@ -123,8 +121,8 @@ public abstract class GuiMixin {
         return instance.getPercentFrozen();
     }
 
-    @Inject(method = "renderHotbarAndDecorations(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/components/spectator/SpectatorGui;renderHotbar(Lnet/minecraft/client/gui/GuiGraphics;)V"))
-    private void spectatorplus$renderHotbar(GuiGraphics guiGraphics, DeltaTracker deltaTracker, CallbackInfo ci,
+    @Inject(method = "extractHotbarAndDecorations(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/components/spectator/SpectatorGui;renderHotbar(Lnet/minecraft/client/gui/GuiGraphicsExtractor;)V"))
+    private void spectatorplus$renderHotbar(GuiGraphicsExtractor guiGraphics, DeltaTracker deltaTracker, CallbackInfo ci,
             @Share("spectated") LocalRef<AbstractClientPlayer> spectatedRef) {
         if (!this.getSpectatorGui().isMenuActive() && !this.minecraft.options.hideGui) {
             final AbstractClientPlayer spectated = SpecUtil.getCameraPlayer(this.minecraft);
@@ -163,7 +161,7 @@ public abstract class GuiMixin {
                                     itemWidth, itemHeight);
                         } else {
                             // Show item icon if present
-                            guiGraphics.renderItem(armorStack, baseX, y);
+                            guiGraphics.item(armorStack, baseX, y);
                             // Draw durability % if item is damageable
                             if (armorStack.isDamageableItem() && armorStack.getMaxDamage() > 0) {
                                 int durability = armorStack.getMaxDamage() - armorStack.getDamageValue();
@@ -187,9 +185,9 @@ public abstract class GuiMixin {
                                 int textX = baseX - spacing - textWidth; // right-aligned to the left of the item
                                 int textY = y + 4; // vertically centered
                                 // Draw numeric part
-                                guiGraphics.drawString(this.minecraft.font, numText, textX, textY, numColor, true);
+                                guiGraphics.text(this.minecraft.font, numText, textX, textY, numColor, true);
                                 // Draw '%' in white
-                                guiGraphics.drawString(this.minecraft.font, percentChar, textX + numTextWidth, textY,
+                                guiGraphics.text(this.minecraft.font, percentChar, textX + numTextWidth, textY,
                                         0xFFFFFFFF, true);
                             }
                         }
@@ -222,7 +220,7 @@ public abstract class GuiMixin {
                             int levelTextY = y + 2;
                             guiGraphics.pose().pushMatrix();
                             guiGraphics.pose().scale(0.5F, 0.5F);
-                            guiGraphics.drawString(this.minecraft.font, levelText, (int) (levelTextX / 0.5F),
+                            guiGraphics.text(this.minecraft.font, levelText, (int) (levelTextX / 0.5F),
                                     (int) (levelTextY / 0.5F), 0xFFFFFFFF, true);
                             guiGraphics.pose().popMatrix();
 
@@ -255,7 +253,7 @@ public abstract class GuiMixin {
         }
     }
 
-    @ModifyExpressionValue(method = "renderHotbarAndDecorations(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/MultiPlayerGameMode;canHurtPlayer()Z"))
+    @ModifyExpressionValue(method = "extractHotbarAndDecorations(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/MultiPlayerGameMode;canHurtPlayer()Z"))
     private boolean spectatorplus$renderHealth(boolean original,
             @Share("spectated") LocalRef<AbstractClientPlayer> spectatedRef) {
         if (original) {
@@ -267,7 +265,7 @@ public abstract class GuiMixin {
                 && this.spectatorplus$isStatusEnabled();
     }
 
-    @Redirect(method = "renderHotbarAndDecorations", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/MultiPlayerGameMode;hasExperience()Z"))
+    @Redirect(method = "extractHotbarAndDecorations", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/MultiPlayerGameMode;hasExperience()Z"))
     private boolean spectatorplus$renderExperience(MultiPlayerGameMode instance) {
         final AbstractClientPlayer spectated = SpecUtil.getCameraPlayer(this.minecraft);
         if (spectated != null) {
@@ -307,7 +305,7 @@ public abstract class GuiMixin {
         }
     }
 
-    @Redirect(method = "renderCrosshair(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getAttackStrengthScale(F)F"))
+    @Redirect(method = "extractCrosshair(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getAttackStrengthScale(F)F"))
     private float spectatorplus$fixCrosshairAttackStrength(LocalPlayer instance, float adjustTicks) {
         if (this.minecraft.getCameraEntity() instanceof Player player) {
             return player.getAttackStrengthScale(adjustTicks);
@@ -315,7 +313,7 @@ public abstract class GuiMixin {
         return instance.getAttackStrengthScale(adjustTicks);
     }
 
-    @Redirect(method = "renderCrosshair(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getCurrentItemAttackStrengthDelay()F"))
+    @Redirect(method = "extractCrosshair(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getCurrentItemAttackStrengthDelay()F"))
     private float spectatorplus$fixCrosshairCurrentItemAttackStrengthDelay(LocalPlayer instance) {
         if (this.minecraft.getCameraEntity() instanceof Player player) {
             return player.getCurrentItemAttackStrengthDelay();
@@ -323,7 +321,7 @@ public abstract class GuiMixin {
         return instance.getCurrentItemAttackStrengthDelay();
     }
 
-    @Redirect(method = "renderSelectedItemName(Lnet/minecraft/client/gui/GuiGraphics;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/MultiPlayerGameMode;canHurtPlayer()Z"))
+    @Redirect(method = "extractSelectedItemName(Lnet/minecraft/client/gui/GuiGraphicsExtractor;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/multiplayer/MultiPlayerGameMode;canHurtPlayer()Z"))
     private boolean spectatorplus$moveHeldItemTooltipUp(MultiPlayerGameMode instance) {
         final AbstractClientPlayer spectated = SpecUtil.getCameraPlayer(this.minecraft);
         if (spectated != null && !spectated.isCreative() && !spectated.isSpectator()) {
@@ -332,7 +330,7 @@ public abstract class GuiMixin {
         return instance.canHurtPlayer();
     }
 
-    @ModifyConstant(method = "renderPlayerHealth(Lnet/minecraft/client/gui/GuiGraphics;)V", constant = @Constant(intValue = 39))
+    @ModifyConstant(method = "extractPlayerHealth(Lnet/minecraft/client/gui/GuiGraphicsExtractor;)V", constant = @Constant(intValue = 39))
     private int spectatorplus$moveHealthDown(int constant) {
         if ((ClientSyncController.syncData == null || ClientSyncController.syncData.selectedHotbarSlot == -1)
                 && SpecUtil.getCameraPlayer(this.minecraft) != null) {
@@ -342,14 +340,14 @@ public abstract class GuiMixin {
         return constant;
     }
 
-    @WrapWithCondition(method = "renderPlayerHealth(Lnet/minecraft/client/gui/GuiGraphics;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Gui;renderFood(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/world/entity/player/Player;II)V"))
-    private boolean spectatorplus$hideNonSyncedFood(Gui instance, GuiGraphics guiGraphics, Player player, int y,
+    @WrapWithCondition(method = "extractPlayerHealth(Lnet/minecraft/client/gui/GuiGraphicsExtractor;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Gui;extractFood(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/world/entity/player/Player;II)V"))
+    private boolean spectatorplus$hideNonSyncedFood(Gui instance, GuiGraphicsExtractor guiGraphics, Player player, int y,
             int x) {
         return (ClientSyncController.syncData != null && ClientSyncController.syncData.foodData != null)
                 || SpecUtil.getCameraPlayer(this.minecraft) == null;
     }
 
-    @Redirect(method = "renderItemHotbar(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;getSelectedSlot()I", opcode = Opcodes.GETFIELD))
+    @Redirect(method = "extractItemHotbar(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;getSelectedSlot()I", opcode = Opcodes.GETFIELD))
     private int spectatorplus$showSyncedSelectedSlot(Inventory inventory) {
         if (ClientSyncController.syncData != null && ClientSyncController.syncData.selectedHotbarSlot != -1
                 && SpecUtil.getCameraPlayer(this.minecraft) != null) {
@@ -358,7 +356,7 @@ public abstract class GuiMixin {
         return inventory.getSelectedSlot();
     }
 
-    @Redirect(method = "renderFood(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/world/entity/player/Player;II)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;getFoodData()Lnet/minecraft/world/food/FoodData;"))
+    @Redirect(method = "extractFood(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/world/entity/player/Player;II)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;getFoodData()Lnet/minecraft/world/food/FoodData;"))
     private FoodData spectatorplus$showSyncedFood(Player instance) {
         if (ClientSyncController.syncData != null && ClientSyncController.syncData.foodData != null
                 && SpecUtil.getCameraPlayer(this.minecraft) != null) {
@@ -367,7 +365,7 @@ public abstract class GuiMixin {
         return instance.getFoodData();
     }
 
-    @Redirect(method = "renderFood(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/world/entity/player/Player;II)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;hasEffect(Lnet/minecraft/core/Holder;)Z"))
+    @Redirect(method = "extractFood(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/world/entity/player/Player;II)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;hasEffect(Lnet/minecraft/core/Holder;)Z"))
     private boolean spectatorplus$showSyncedFoodSprite(Player instance,
             net.minecraft.core.Holder<net.minecraft.world.effect.MobEffect> effect) {
         final LocalPlayer player = this.minecraft.player;
@@ -377,7 +375,7 @@ public abstract class GuiMixin {
         return instance.hasEffect(effect);
     }
 
-    @Redirect(method = "renderItemHotbar(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;getItem(I)Lnet/minecraft/world/item/ItemStack;"))
+    @Redirect(method = "extractItemHotbar(Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/client/DeltaTracker;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;getItem(I)Lnet/minecraft/world/item/ItemStack;"))
     private ItemStack spectatorplus$showSyncedItems(Inventory instance, int slot) {
         if (ClientSyncController.syncData != null && ClientSyncController.syncData.selectedHotbarSlot != -1
                 && SpecUtil.getCameraPlayer(this.minecraft) != null) {
@@ -386,7 +384,7 @@ public abstract class GuiMixin {
         return instance.getItem(slot);
     }
 
-    @Redirect(method = "renderHotbarAndDecorations", at = @At(value = "FIELD", target = "Lnet/minecraft/client/player/LocalPlayer;experienceLevel:I", opcode = Opcodes.GETFIELD))
+    @Redirect(method = "extractHotbarAndDecorations", at = @At(value = "FIELD", target = "Lnet/minecraft/client/player/LocalPlayer;experienceLevel:I", opcode = Opcodes.GETFIELD))
     private int spectatorplus$showSyncedExperienceLevel(LocalPlayer instance) {
         if (ClientSyncController.syncData != null && ClientSyncController.syncData.experienceLevel != -1
                 && SpecUtil.getCameraPlayer(this.minecraft) != null) {

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/MinecraftMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/MinecraftMixin.java
@@ -24,7 +24,7 @@ public abstract class MinecraftMixin {
     @Inject(method = "setCameraEntity(Lnet/minecraft/world/entity/Entity;)V", at = @At(value = "TAIL"))
     private void spectatorplus$resetSyncDataOnCameraSwitch(Entity viewingEntity, CallbackInfo ci) {
         if (ClientSyncController.syncData != null && (viewingEntity == null || !ClientSyncController.syncData.playerId.equals(viewingEntity.getUUID()))) {
-            ClientSyncController.setSyncData(null);
+            ClientSyncController.createSyncDataIfNull(null);
         }
     }
 
@@ -64,7 +64,7 @@ public abstract class MinecraftMixin {
 
         if (ClientPlayNetworking.canSend(ServerboundOpenedInventorySyncPacket.TYPE)) {
             // just let the server we've opened our inventory. this is used to sync with other users spectating this client
-            ClientPlayNetworking.send(new ServerboundOpenedInventorySyncPacket());
+            ClientPlayNetworking.send(new ServerboundOpenedInventorySyncPacket(true));
         }
         return true;
     }

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/screen/AbstractContainerScreenMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/screen/AbstractContainerScreenMixin.java
@@ -5,13 +5,13 @@ import com.hpfxd.spectatorplus.fabric.client.gui.screens.ItemMoveAnimation;
 import com.hpfxd.spectatorplus.fabric.client.sync.ClientSyncController;
 import com.hpfxd.spectatorplus.fabric.client.sync.screen.ScreenSyncController;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.Mth;
 import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.ClickAction;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
@@ -48,31 +48,31 @@ public abstract class AbstractContainerScreenMixin {
 
     @Shadow @Final private static Identifier SLOT_HIGHLIGHT_BACK_SPRITE;
     @Shadow @Final private static Identifier SLOT_HIGHLIGHT_FRONT_SPRITE;
-    @Shadow protected abstract void renderFloatingItem(GuiGraphics guiGraphics, ItemStack stack, int x, int y, String text);
+    @Shadow protected abstract void extractFloatingItem(GuiGraphicsExtractor guiGraphics, ItemStack stack, int x, int y, String text);
     @Shadow @Final protected AbstractContainerMenu menu;
     @Shadow @Nullable protected abstract Slot getHoveredSlot(double mouseX, double mouseY);
     @Shadow protected int leftPos;
     @Shadow protected int topPos;
 
     @Inject(
-            method = "slotClicked(Lnet/minecraft/world/inventory/Slot;IILnet/minecraft/world/inventory/ClickType;)V",
+            method = "slotClicked(Lnet/minecraft/world/inventory/Slot;IILnet/minecraft/world/inventory/ClickAction;)V",
             at = @At("HEAD"),
             cancellable = true
     )
-    private void spectatorplus$noClickingOnSyncedScreens(Slot slot, int slotId, int mouseButton, ClickType type, CallbackInfo ci) {
+    private void spectatorplus$noClickingOnSyncedScreens(Slot slot, int slotId, int mouseButton, ClickAction type, CallbackInfo ci) {
         if (this.spectatorplus$isSyncedScreen()) {
             ci.cancel();
         }
     }
 
     @Inject(
-            method = "renderContents",
+            method = "extractContents",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/client/gui/screens/inventory/AbstractContainerScreen;renderLabels(Lnet/minecraft/client/gui/GuiGraphics;II)V"
+                    target = "Lnet/minecraft/client/gui/screens/inventory/AbstractContainerScreen;extractLabels(Lnet/minecraft/client/gui/GuiGraphicsExtractor;II)V"
             )
     )
-    private void spectatorplus$renderSyncedCursorItem(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick, CallbackInfo ci) {
+    private void spectatorplus$renderContents(GuiGraphicsExtractor guiGraphics, int mouseX, int mouseY, float partialTick, CallbackInfo ci) {
         if (!this.spectatorplus$isSyncedScreen()) {
             return;
         }
@@ -120,12 +120,12 @@ public abstract class AbstractContainerScreenMixin {
     }
 
     @Unique
-    private void spectatorplus$renderCursorItem(GuiGraphics guiGraphics, ItemStack stack, int cursorX, int cursorY) {
+    private void spectatorplus$renderCursorItem(GuiGraphicsExtractor guiGraphics, ItemStack stack, int cursorX, int cursorY) {
         final Slot hoverSlot = this.getHoveredSlot(cursorX + this.leftPos + 8, cursorY + this.topPos + 8);
         if (hoverSlot != null && hoverSlot.isHighlightable()) {
             guiGraphics.blitSprite(RenderPipelines.GUI_TEXTURED, SLOT_HIGHLIGHT_BACK_SPRITE, hoverSlot.x - 4, hoverSlot.y - 4, 24, 24);
         }
-        this.renderFloatingItem(guiGraphics, stack, cursorX, cursorY, null);
+        this.extractFloatingItem(guiGraphics, stack, cursorX, cursorY, null);
         if (hoverSlot != null && hoverSlot.isHighlightable()) {
             guiGraphics.blitSprite(RenderPipelines.GUI_TEXTURED, SLOT_HIGHLIGHT_FRONT_SPRITE, hoverSlot.x - 4, hoverSlot.y - 4, 24, 24);
         }
@@ -144,7 +144,7 @@ public abstract class AbstractContainerScreenMixin {
     }
 
     @ModifyExpressionValue(
-            method = "renderTooltip(Lnet/minecraft/client/gui/GuiGraphics;II)V",
+            method = "extractTooltip(Lnet/minecraft/client/gui/GuiGraphicsExtractor;II)V",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/inventory/Slot;hasItem()Z")
     )
     private boolean spectatorplus$hideTooltipUntilMouseMove(boolean original) {
@@ -153,8 +153,8 @@ public abstract class AbstractContainerScreenMixin {
 
     @ModifyExpressionValue(
             method = {
-                    "renderSlotHighlightBack(Lnet/minecraft/client/gui/GuiGraphics;)V",
-                    "renderSlotHighlightFront(Lnet/minecraft/client/gui/GuiGraphics;)V"
+                    "extractSlotHighlightBack(Lnet/minecraft/client/gui/GuiGraphicsExtractor;)V",
+                    "extractSlotHighlightFront(Lnet/minecraft/client/gui/GuiGraphicsExtractor;)V"
             },
             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/inventory/Slot;isHighlightable()Z", ordinal = 0)
     )

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/screen/AbstractContainerScreenMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/screen/AbstractContainerScreenMixin.java
@@ -11,7 +11,7 @@ import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.Mth;
 import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.ClickAction;
+import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
@@ -55,11 +55,11 @@ public abstract class AbstractContainerScreenMixin {
     @Shadow protected int topPos;
 
     @Inject(
-            method = "slotClicked(Lnet/minecraft/world/inventory/Slot;IILnet/minecraft/world/inventory/ClickAction;)V",
+            method = "slotClicked(Lnet/minecraft/world/inventory/Slot;IILnet/minecraft/world/inventory/ContainerInput;)V",
             at = @At("HEAD"),
             cancellable = true
     )
-    private void spectatorplus$noClickingOnSyncedScreens(Slot slot, int slotId, int mouseButton, ClickAction type, CallbackInfo ci) {
+    private void spectatorplus$noClickingOnSyncedScreens(Slot slot, int slotId, int mouseButton, ContainerInput type, CallbackInfo ci) {
         if (this.spectatorplus$isSyncedScreen()) {
             ci.cancel();
         }

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/screen/InventoryScreenMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/screen/InventoryScreenMixin.java
@@ -5,7 +5,7 @@ import com.hpfxd.spectatorplus.fabric.client.gui.screens.SyncedInventoryScreen;
 import com.hpfxd.spectatorplus.fabric.client.sync.screen.ScreenSyncController;
 import com.hpfxd.spectatorplus.fabric.client.util.SpecUtil;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.client.player.AbstractClientPlayer;
@@ -59,16 +59,16 @@ public abstract class InventoryScreenMixin extends AbstractContainerScreen<Inven
     }
 
     @Redirect(
-            method = "renderBg(Lnet/minecraft/client/gui/GuiGraphics;FII)V",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/inventory/InventoryScreen;renderEntityInInventoryFollowsMouse(Lnet/minecraft/client/gui/GuiGraphics;IIIIIFFFLnet/minecraft/world/entity/LivingEntity;)V")
+            method = "extractBackground(Lnet/minecraft/client/gui/GuiGraphicsExtractor;IIF)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/inventory/InventoryScreen;extractEntityInInventoryFollowsMouse(Lnet/minecraft/client/gui/GuiGraphicsExtractor;IIIIIFFFLnet/minecraft/world/entity/LivingEntity;)V")
     )
-    private void spectatorplus$renderTargetPlayerInInventory(GuiGraphics guiGraphics, int x1, int y1, int x2, int y2, int scale, float yOffset, float mouseX, float mouseY, LivingEntity entity) {
+    private void spectatorplus$renderTargetPlayerInInventory(GuiGraphicsExtractor guiGraphics, int x1, int y1, int x2, int y2, int scale, float yOffset, float mouseX, float mouseY, LivingEntity entity) {
         if (((Object) this) instanceof SyncedInventoryScreen) {
             final AbstractClientPlayer spectated = SpecUtil.getCameraPlayer(Minecraft.getInstance());
             if (spectated != null) {
                 entity = spectated;
             }
         }
-        InventoryScreen.renderEntityInInventoryFollowsMouse(guiGraphics, x1, y1, x2, y2, scale, yOffset, mouseX, mouseY, entity);
+        InventoryScreen.extractEntityInInventoryFollowsMouse(guiGraphics, x1, y1, x2, y2, scale, yOffset, mouseX, mouseY, entity);
     }
 }

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/screen/MenuScreensMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/screen/MenuScreensMixin.java
@@ -50,18 +50,26 @@ public abstract class MenuScreensMixin {
 
                         // if no inventory could be created, we close the inventory
                     } else {
-                        final Inventory inventory;
-                        if (hasInventory) {
-                            inventory = ScreenSyncController.syncedInventory;
+                        // Handle container screens
+                        if (ClientSyncController.syncData.screen.containerType != null) {
+                            // Open container screen with proper type and size
+                            ScreenSyncController.openContainerScreen(mc,
+                                ClientSyncController.syncData.screen.containerType,
+                                ClientSyncController.syncData.screen.containerSize);
                         } else {
-                            inventory = mc.player.getInventory();
+                            // Fallback to original screen creation for unknown container types
+                            final Inventory inventory;
+                            if (hasInventory) {
+                                inventory = ScreenSyncController.syncedInventory;
+                            } else {
+                                inventory = mc.player.getInventory();
+                            }
+
+                            final M menu = type.create(windowId, inventory);
+                            final S screen = screenConstructor.create(menu, inventory, title);
+
+                            ScreenSyncController.handleNewSyncedScreen(mc, screen);
                         }
-
-                        final M menu = type.create(windowId, inventory);
-                        final S screen = screenConstructor.create(menu, inventory, title);
-
-                        ScreenSyncController.handleNewSyncedScreen(mc, screen);
-                        return;
                     }
                 }
             }

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/screen/MenuScreensMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/screen/MenuScreensMixin.java
@@ -56,6 +56,7 @@ public abstract class MenuScreensMixin {
                             ScreenSyncController.openContainerScreen(mc,
                                 ClientSyncController.syncData.screen.containerType,
                                 ClientSyncController.syncData.screen.containerSize);
+                            return;
                         } else {
                             // Fallback to original screen creation for unknown container types
                             final Inventory inventory;
@@ -69,6 +70,7 @@ public abstract class MenuScreensMixin {
                             final S screen = screenConstructor.create(menu, inventory, title);
 
                             ScreenSyncController.handleNewSyncedScreen(mc, screen);
+                            return;
                         }
                     }
                 }

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/screen/ScreenMixin.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/mixin/screen/ScreenMixin.java
@@ -1,0 +1,26 @@
+package com.hpfxd.spectatorplus.fabric.client.mixin.screen;
+
+import com.hpfxd.spectatorplus.fabric.sync.packet.ServerboundOpenedInventorySyncPacket;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.client.gui.screens.inventory.InventoryScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Screen.class)
+public class ScreenMixin {
+
+    @Inject(method = "onClose()V", at = @At("HEAD"))
+    private void spectatorplus$onScreenClose(CallbackInfo ci) {
+        // Check if this is an inventory or container screen being closed
+        if ((Object) this instanceof InventoryScreen || (Object) this instanceof AbstractContainerScreen) {
+            // Notify server that we closed our inventory/container
+            if (ClientPlayNetworking.canSend(ServerboundOpenedInventorySyncPacket.TYPE)) {
+                ClientPlayNetworking.send(new ServerboundOpenedInventorySyncPacket(false));
+            }
+        }
+    }
+}

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/ClientSyncController.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/ClientSyncController.java
@@ -2,7 +2,6 @@ package com.hpfxd.spectatorplus.fabric.client.sync;
 
 import com.hpfxd.spectatorplus.fabric.client.sync.screen.ScreenSyncController;
 import com.hpfxd.spectatorplus.fabric.client.util.EffectUtil;
-import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundContainerSyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundExperienceSyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundFoodSyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundHotbarSyncPacket;
@@ -19,7 +18,7 @@ import java.util.UUID;
 
 public class ClientSyncController {
     public static ClientSyncData syncData;
-    private static Minecraft minecraft = Minecraft.getInstance();
+    private static final Minecraft minecraft = Minecraft.getInstance();
 
     public static void init() {
         ClientPlayNetworking.registerGlobalReceiver(ClientboundExperienceSyncPacket.TYPE, ClientSyncController::handle);

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/ClientSyncData.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/ClientSyncData.java
@@ -28,7 +28,7 @@ public class ClientSyncData {
         this.playerId = playerId;
     }
 
-    public void setScreen() {
+    public void createScreenIfNull() {
         if (this.screen == null) {
             this.screen = new ScreenSyncData();
         }

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/screen/ScreenSyncController.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/screen/ScreenSyncController.java
@@ -1,33 +1,35 @@
 package com.hpfxd.spectatorplus.fabric.client.sync.screen;
 
 import com.hpfxd.spectatorplus.fabric.client.gui.screens.SyncedInventoryScreen;
+import com.hpfxd.spectatorplus.fabric.client.gui.screens.DummyContainer;
 import com.hpfxd.spectatorplus.fabric.client.mixin.InventoryAccessor;
+import com.hpfxd.spectatorplus.fabric.client.sync.ClientSyncController;
 import com.hpfxd.spectatorplus.fabric.client.util.SpecUtil;
+import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundContainerSyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundInventorySyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundScreenCursorSyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundScreenSyncPacket;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.screen.v1.ScreenEvents;
-import net.fabricmc.fabric.api.networking.v1.PacketSender;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.gui.screens.inventory.MenuAccess;
-import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.core.NonNullList;
+import net.minecraft.client.gui.screens.inventory.*;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.EntityEquipment;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.*;
 import net.minecraft.world.item.ItemStack;
 
-import static com.hpfxd.spectatorplus.fabric.client.sync.ClientSyncController.setSyncData;
+import static com.hpfxd.spectatorplus.fabric.client.sync.ClientSyncController.createSyncDataIfNull;
 import static com.hpfxd.spectatorplus.fabric.client.sync.ClientSyncController.syncData;
 
 public class ScreenSyncController {
     public static boolean isPendingOpen = false;
 
     public static int syncedWindowId = Integer.MIN_VALUE;
-    public static Inventory syncedInventory;
+    public static Inventory syncedInventory;//dummy inventory
     public static Screen syncedScreen;
 
     public static void init() {
@@ -37,70 +39,231 @@ public class ScreenSyncController {
             }
         });
 
-        ClientPlayNetworking.registerGlobalReceiver(ClientboundScreenSyncPacket.TYPE, ScreenSyncController::handle);
         ClientPlayNetworking.registerGlobalReceiver(ClientboundInventorySyncPacket.TYPE, ScreenSyncController::handle);
+        ClientPlayNetworking.registerGlobalReceiver(ClientboundContainerSyncPacket.TYPE, ScreenSyncController::handle);
+        ClientPlayNetworking.registerGlobalReceiver(ClientboundScreenSyncPacket.TYPE, ScreenSyncController::handle);
         ClientPlayNetworking.registerGlobalReceiver(ClientboundScreenCursorSyncPacket.TYPE, ScreenSyncController::handle);
     }
 
+    private static void handle(ClientboundContainerSyncPacket packet, ClientPlayNetworking.Context context) {
+        createSyncDataIfNull(packet.playerId());
+        syncData.createScreenIfNull();
+
+        // Set container data
+        syncData.screen.containerType = packet.containerType();
+        syncData.screen.containerSize = packet.containerSize();
+
+        // Initialize container items if not already done
+        syncData.screen.initializeContainerItems(packet.containerSize());
+
+        // Update container items
+        // Support incremental updates: null items in the array mean "don't update this slot"
+        syncData.screen.updateContainerItems(packet.items());
+    }
+
     private static void handle(ClientboundScreenSyncPacket packet, ClientPlayNetworking.Context context) {
-        setSyncData(packet.playerId());
-        syncData.setScreen();
+        createSyncDataIfNull(packet.playerId());
+        syncData.createScreenIfNull();
+
+        // If the packet indicates the screen is closed, close it on the client
+        if (packet.isScreenClosed()) {
+            final Minecraft mc = Minecraft.getInstance();
+            mc.execute(ScreenSyncController::closeSyncedInventory);
+            return;
+        }
 
         isPendingOpen = true;
         syncData.screen.isSurvivalInventory = packet.isSurvivalInventory();
         syncData.screen.isClientRequested = packet.isClientRequested();
         syncData.screen.hasDummySlots = packet.hasDummySlots();
+
+        // If this is a survival inventory screen sync, try to open it immediately
+        if (syncData.screen.isSurvivalInventory) {
+            final Minecraft mc = Minecraft.getInstance();
+            mc.execute(() -> {
+                if (isPendingOpen) {
+                    // Create the synced inventory first, so the mixin can use it
+                    final Player spectated = SpecUtil.getCameraPlayer(mc);
+                    if (spectated != null && createInventory(spectated)) {
+                        openPlayerInventory(mc);
+                    }
+                }
+            });
+        }
     }
 
     private static void handle(ClientboundInventorySyncPacket packet, ClientPlayNetworking.Context context) {
-        setSyncData(packet.playerId());
-        syncData.setScreen();
+        createSyncDataIfNull(packet.playerId());
+        syncData.createScreenIfNull();
 
-        if (syncData.screen.inventoryItems == null || syncData.screen.inventoryItems.size() != ClientboundInventorySyncPacket.ITEMS_LENGTH) {
-            syncData.screen.inventoryItems = NonNullList.withSize(ClientboundInventorySyncPacket.ITEMS_LENGTH, ItemStack.EMPTY);
-        }
+        syncData.screen.initializeInventoryItems(ClientboundInventorySyncPacket.ITEMS_LENGTH);
 
         final ItemStack[] items = packet.items();
-        for (int slot = 0; slot < items.length; slot++) {
-            final ItemStack item = items[slot];
-            if (item != null) {
-                syncData.screen.inventoryItems.set(slot, item);
-                if (syncedInventory != null) {
-                    syncedInventory.setItem(slot, item);
-                }
-            }
-        }
-        // Also update global armorItems for convenience
-        if (syncData.armorItems != null && items.length >= 40) {
-            for (int slot = 36; slot < 40; slot++) {
-                final ItemStack item = items[slot];
-                if (item != null) {
-                    syncData.armorItems.set(slot - 36, item);
-                }
-            }
-        }
+        syncData.screen.updateInventoryItems(items);
     }
 
     private static void handle(ClientboundScreenCursorSyncPacket packet, ClientPlayNetworking.Context context) {
-        setSyncData(packet.playerId());
-        syncData.setScreen();
+        createSyncDataIfNull(packet.playerId());
+        syncData.createScreenIfNull();
 
         syncData.screen.cursorItem = packet.cursor();
         syncData.screen.cursorItemSlot = packet.originSlot();
     }
 
     public static void closeSyncedInventory() {
-        if (syncedScreen != null) {
-            syncedScreen.onClose();
-            syncedInventory = null;
-        }
+        final Minecraft mc = Minecraft.getInstance();
+        mc.setScreen(null);
+        syncedScreen = null;
+
+        syncedInventory = null;
+        syncedWindowId = Integer.MIN_VALUE;
+        isPendingOpen = false;
+        syncData.screen = null;
     }
 
     public static void openPlayerInventory(Minecraft mc) {
-        final Player player = SpecUtil.getCameraPlayer(mc);
-        final SyncedInventoryScreen screen = new SyncedInventoryScreen(player);
-
+        final Player spectated = SpecUtil.getCameraPlayer(mc);
+        final SyncedInventoryScreen screen = new SyncedInventoryScreen(spectated);
         handleNewSyncedScreen(mc, screen);
+    }
+
+    public static void openContainerScreen(Minecraft mc, MenuType<?> containerType, int containerSize) {
+        final Player spectated = SpecUtil.getCameraPlayer(mc);
+        if (spectated != null && mc.player != null && syncData != null && syncData.screen != null) {
+            // Create dummy container for the synced screen
+            DummyContainer containerInventory = new DummyContainer(containerSize);
+
+            // Populate the container with synced items using helper method
+            syncData.screen.populateContainer(containerInventory);
+
+            Inventory playerInventory = syncedInventory != null ? syncedInventory : mc.player.getInventory();
+            Screen screen = createVanillaContainerScreen(containerType, syncedWindowId, playerInventory, containerInventory);
+
+            if (screen instanceof MenuAccess<?>) {
+                handleNewSyncedScreen(mc, (Screen & MenuAccess<?>) screen);
+            }
+        }
+    }
+
+    private static Screen createVanillaContainerScreen(MenuType<?> type, int windowId, Inventory playerInventory, DummyContainer containerInventory) {
+        Component title = Component.literal("Container");
+
+        // For furnace-like containers
+        if (type == MenuType.FURNACE) {
+            FurnaceMenu menu = new FurnaceMenu(windowId, playerInventory, containerInventory, new SimpleContainerData(4));
+            return new FurnaceScreen(menu, playerInventory, title);
+        } else if (type == MenuType.BLAST_FURNACE) {
+            BlastFurnaceMenu menu = new BlastFurnaceMenu(windowId, playerInventory, containerInventory, new SimpleContainerData(4));
+            return new BlastFurnaceScreen(menu, playerInventory, title);
+        } else if (type == MenuType.SMOKER) {
+            SmokerMenu menu = new SmokerMenu(windowId, playerInventory, containerInventory, new SimpleContainerData(4));
+            return new SmokerScreen(menu, playerInventory, title);
+        }
+
+        // For brewing stand
+        else if (type == MenuType.BREWING_STAND) {
+            BrewingStandMenu menu = new BrewingStandMenu(windowId, playerInventory, containerInventory, new SimpleContainerData(2));
+            return new BrewingStandScreen(menu, playerInventory, title);
+        }
+
+        // For anvil
+        else if (type == MenuType.ANVIL) {
+            AnvilMenu menu = new AnvilMenu(windowId, playerInventory, ContainerLevelAccess.NULL);
+            return new AnvilScreen(menu, playerInventory, title);
+        }
+
+        // For enchanting table
+        else if (type == MenuType.ENCHANTMENT) {
+            EnchantmentMenu menu = new EnchantmentMenu(windowId, playerInventory, ContainerLevelAccess.NULL);
+            return new EnchantmentScreen(menu, playerInventory, title);
+        }
+
+        // For crafting table
+        else if (type == MenuType.CRAFTING) {
+            CraftingMenu menu = new CraftingMenu(windowId, playerInventory, ContainerLevelAccess.NULL);
+            return new CraftingScreen(menu, playerInventory, title);
+        }
+
+        // For grindstone
+        else if (type == MenuType.GRINDSTONE) {
+            GrindstoneMenu menu = new GrindstoneMenu(windowId, playerInventory, ContainerLevelAccess.NULL);
+            return new GrindstoneScreen(menu, playerInventory, title);
+        }
+
+        // For loom
+        else if (type == MenuType.LOOM) {
+            LoomMenu menu = new LoomMenu(windowId, playerInventory, ContainerLevelAccess.NULL);
+            return new LoomScreen(menu, playerInventory, title);
+        }
+
+        // For stonecutter
+        else if (type == MenuType.STONECUTTER) {
+            StonecutterMenu menu = new StonecutterMenu(windowId, playerInventory, ContainerLevelAccess.NULL);
+            return new StonecutterScreen(menu, playerInventory, title);
+        }
+
+        // For cartography table
+        else if (type == MenuType.CARTOGRAPHY_TABLE) {
+            CartographyTableMenu menu = new CartographyTableMenu(windowId, playerInventory, ContainerLevelAccess.NULL);
+            return new CartographyTableScreen(menu, playerInventory, title);
+        }
+
+        // For smithing table
+        else if (type == MenuType.SMITHING) {
+            SmithingMenu menu = new SmithingMenu(windowId, playerInventory, ContainerLevelAccess.NULL);
+            return new SmithingScreen(menu, playerInventory, title);
+        }
+
+        // For generic containers (chests, etc.)
+        else if (type == MenuType.GENERIC_9x1) {
+            ChestMenu menu = new ChestMenu(MenuType.GENERIC_9x1, windowId, playerInventory, containerInventory, 1);
+            return new ContainerScreen(menu, playerInventory, title);
+        } else if (type == MenuType.GENERIC_9x2) {
+            ChestMenu menu = new ChestMenu(MenuType.GENERIC_9x2, windowId, playerInventory, containerInventory, 2);
+            return new ContainerScreen(menu, playerInventory, title);
+        } else if (type == MenuType.GENERIC_9x3) {
+            ChestMenu menu = new ChestMenu(MenuType.GENERIC_9x3, windowId, playerInventory, containerInventory, 3);
+            return new ContainerScreen(menu, playerInventory, title);
+        } else if (type == MenuType.GENERIC_9x4) {
+            ChestMenu menu = new ChestMenu(MenuType.GENERIC_9x4, windowId, playerInventory, containerInventory, 4);
+            return new ContainerScreen(menu, playerInventory, title);
+        } else if (type == MenuType.GENERIC_9x5) {
+            ChestMenu menu = new ChestMenu(MenuType.GENERIC_9x5, windowId, playerInventory, containerInventory, 5);
+            return new ContainerScreen(menu, playerInventory, title);
+        } else if (type == MenuType.GENERIC_9x6) {
+            ChestMenu menu = new ChestMenu(MenuType.GENERIC_9x6, windowId, playerInventory, containerInventory, 6);
+            return new ContainerScreen(menu, playerInventory, title);
+        }
+
+        // For dispenser and dropper
+        else if (type == MenuType.GENERIC_3x3) {
+            DispenserMenu menu = new DispenserMenu(windowId, playerInventory, containerInventory);
+            return new DispenserScreen(menu, playerInventory, title);
+        }
+
+        // For hopper
+        else if (type == MenuType.HOPPER) {
+            HopperMenu menu = new HopperMenu(windowId, playerInventory, containerInventory);
+            return new HopperScreen(menu, playerInventory, title);
+        }
+
+        // For shulker box
+        else if (type == MenuType.SHULKER_BOX) {
+            ShulkerBoxMenu menu = new ShulkerBoxMenu(windowId, playerInventory, containerInventory);
+            return new ShulkerBoxScreen(menu, playerInventory, title);
+        }
+
+        // For beacon
+        else if (type == MenuType.BEACON) {
+            BeaconMenu menu = new BeaconMenu(windowId, containerInventory, new SimpleContainerData(3), ContainerLevelAccess.NULL);
+            return new BeaconScreen(menu, playerInventory, title);
+        }
+
+        // Fallback to generic 3x9 chest for unknown types (including lectern which has no GUI)
+        else {
+            ChestMenu menu = new ChestMenu(MenuType.GENERIC_9x3, windowId, playerInventory, containerInventory, 3);
+            return new ContainerScreen(menu, playerInventory, title);
+        }
     }
 
     public static <S extends Screen & MenuAccess<?>> void handleNewSyncedScreen(Minecraft mc, S screen) {
@@ -108,6 +271,7 @@ public class ScreenSyncController {
         mc.player.containerMenu = screen.getMenu();
         mc.setScreen(screen);
 
+        // sanity check to avoid registering events on the wrong screen
         if (mc.screen != screen) {
             syncedInventory = null;
             syncData.screen = null;
@@ -125,18 +289,13 @@ public class ScreenSyncController {
     }
 
     public static boolean createInventory(Player spectated) {
-        if (syncData.screen.inventoryItems == null) {
+        if (!syncData.screen.hasInventoryItems()) {
             return false;
         }
 
         EntityEquipment equipment = ((InventoryAccessor)spectated.getInventory()).getEquipment();
         syncedInventory = new Inventory(spectated, equipment);
-
-        // Set all inventory slots (0-39)
-        for (int i = 0; i < syncData.screen.inventoryItems.size(); i++) {
-            syncedInventory.setItem(i, syncData.screen.inventoryItems.get(i));
-        }
-        // No direct access to armor list; setting slots 36-39 is sufficient for GUI
+        syncData.screen.populateInventory(syncedInventory);
         return true;
     }
 }

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/screen/ScreenSyncController.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/screen/ScreenSyncController.java
@@ -1,9 +1,8 @@
 package com.hpfxd.spectatorplus.fabric.client.sync.screen;
 
-import com.hpfxd.spectatorplus.fabric.client.gui.screens.SyncedInventoryScreen;
 import com.hpfxd.spectatorplus.fabric.client.gui.screens.DummyContainer;
+import com.hpfxd.spectatorplus.fabric.client.gui.screens.SyncedInventoryScreen;
 import com.hpfxd.spectatorplus.fabric.client.mixin.InventoryAccessor;
-import com.hpfxd.spectatorplus.fabric.client.sync.ClientSyncController;
 import com.hpfxd.spectatorplus.fabric.client.util.SpecUtil;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundContainerSyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundInventorySyncPacket;
@@ -268,6 +267,7 @@ public class ScreenSyncController {
 
     public static <S extends Screen & MenuAccess<?>> void handleNewSyncedScreen(Minecraft mc, S screen) {
         isPendingOpen = false;
+        if(mc.player == null) return;
         mc.player.containerMenu = screen.getMenu();
         mc.setScreen(screen);
 

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/screen/ScreenSyncController.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/screen/ScreenSyncController.java
@@ -117,7 +117,9 @@ public class ScreenSyncController {
         syncedInventory = null;
         syncedWindowId = Integer.MIN_VALUE;
         isPendingOpen = false;
-        syncData.screen = null;
+        if (syncData != null) {
+            syncData.screen = null;
+        }
     }
 
     public static void openPlayerInventory(Minecraft mc) {

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/screen/ScreenSyncData.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/screen/ScreenSyncData.java
@@ -5,7 +5,6 @@ import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.ItemStack;
-import org.jetbrains.annotations.NotNull;
 
 import static com.hpfxd.spectatorplus.fabric.client.sync.ClientSyncController.syncData;
 

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/screen/ScreenSyncData.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/sync/screen/ScreenSyncData.java
@@ -1,7 +1,13 @@
 package com.hpfxd.spectatorplus.fabric.client.sync.screen;
 
 import net.minecraft.core.NonNullList;
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import static com.hpfxd.spectatorplus.fabric.client.sync.ClientSyncController.syncData;
 
 public class ScreenSyncData {
     /**
@@ -11,10 +17,139 @@ public class ScreenSyncData {
      */
     public NonNullList<ItemStack> inventoryItems;
 
+    /**
+     * Container items for non-inventory screens
+     */
+    public NonNullList<ItemStack> containerItems;
+
+    /**
+     * Container type for determining proper GUI rendering
+     */
+    public MenuType<?> containerType;
+
+    /**
+     * Container size for dynamic containers like chests
+     */
+    public int containerSize;
+
     public boolean isSurvivalInventory;
     public boolean isClientRequested;
     public boolean hasDummySlots;
 
     public ItemStack cursorItem = ItemStack.EMPTY;
     public int cursorItemSlot = -1;
+
+    /**
+     * Initialize or resize container items to the specified size
+     * @param size the desired size of the container
+     */
+    public void initializeContainerItems(int size) {
+        if (containerItems == null || containerItems.size() != size) {
+            containerItems = NonNullList.withSize(size, ItemStack.EMPTY);
+        }
+    }
+
+    /**
+     * Update container item at the specified slot
+     * @param slot the slot index
+     * @param item the item to set (null means skip this slot)
+     */
+    public void updateContainerItem(int slot, ItemStack item) {
+        if (containerItems != null && slot >= 0 && slot < containerItems.size() && item != null) {
+            containerItems.set(slot, item.isEmpty() ? ItemStack.EMPTY : item);
+        }
+    }
+
+    /**
+     * Update multiple container items from an array
+     * @param items array of items to update (null items are skipped)
+     */
+    public void updateContainerItems(ItemStack[] items) {
+        if (containerItems == null || items == null) {
+            return;
+        }
+        for (int i = 0; i < items.length && i < containerItems.size(); i++) {
+            updateContainerItem(i, items[i]);
+        }
+    }
+
+    /**
+     * Populate a Container with the synced container items
+     * @param container the container to populate
+     */
+    public void populateContainer(Container container) {
+        if (containerItems == null || container == null) {
+            return;
+        }
+        for (int i = 0; i < containerItems.size() && i < container.getContainerSize(); i++) {
+            container.setItem(i, containerItems.get(i));
+        }
+    }
+
+    /**
+     * Check if container items are initialized
+     * @return true if containerItems is not null
+     */
+    public boolean hasContainerItems() {
+        return containerItems != null;
+    }
+
+    /**
+     * Initialize or resize inventory items to the specified size
+     * @param size the desired size of the inventory
+     */
+    public void initializeInventoryItems(int size) {
+        if (inventoryItems == null || inventoryItems.size() != size) {
+            inventoryItems = NonNullList.withSize(size, ItemStack.EMPTY);
+        }
+    }
+
+    /**
+     * Update inventory item at the specified slot
+     * @param slot the slot index
+     * @param item the item to set
+     */
+    public void updateInventoryItem(int slot, ItemStack item) {
+        if (inventoryItems != null && slot >= 0 && slot < inventoryItems.size() && item != null) {
+            inventoryItems.set(slot, item);
+        }
+    }
+
+    public void updateInventoryItems(ItemStack[] items) {
+        if (inventoryItems == null) return;
+
+        for (int i = 0; i < items.length && i < inventoryItems.size(); i++) {
+            updateInventoryItem(i, items[i]);
+        }
+        //update armor items
+        if (syncData != null) {
+            for (int i = 36; i < 40 && i < items.length; i++) {
+                final ItemStack item = items[i];
+                if (item != null) {
+                    syncData.armorItems.set(i - 36, item);
+                }
+            }
+        }
+    }
+
+    /**
+     * Populate an Inventory with the synced inventory items
+     * @param inventory the inventory to populate
+     */
+    public void populateInventory(Inventory inventory) {
+        if (inventoryItems == null || inventory == null) {
+            return;
+        }
+        for (int i = 0; i < inventoryItems.size(); i++) {
+            inventory.setItem(i, inventoryItems.get(i));
+        }
+    }
+
+    /**
+     * Check if inventory items are initialized
+     * @return true if inventoryItems is not null
+     */
+    public boolean hasInventoryItems() {
+        return inventoryItems != null;
+    }
 }

--- a/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/util/EffectUtil.java
+++ b/fabric/src/client/java/com/hpfxd/spectatorplus/fabric/client/util/EffectUtil.java
@@ -16,7 +16,7 @@ public class EffectUtil {
     private static final Map<Holder<MobEffect>, MobEffectInstance> activeEffects = new HashMap<>();
 
     public static void updateEffectInstances(List<SyncedEffect> effects) {
-        // 收集新的效果
+        // collecting new effects
         Set<Holder<MobEffect>> newEffects = new HashSet<>();
 
         for (SyncedEffect syncedEffect : effects) {
@@ -25,10 +25,10 @@ public class EffectUtil {
             newEffects.add(effect);
         }
 
-        // 移除不再存在的效果
+        // remove effects that are no longer present
         activeEffects.entrySet().removeIf(entry -> !newEffects.contains(entry.getKey()));
 
-        // 添加新效果（保持现有实例的BlendState）
+        // add new effects (keep existing instances' BlendState)
         for (SyncedEffect syncedEffect : effects) {
             Holder<MobEffect> effect = BuiltInRegistries.MOB_EFFECT.get(Identifier.parse(syncedEffect.effectKey))
                     .orElseThrow(() -> new IllegalArgumentException("Unknown effect: " + syncedEffect.effectKey));
@@ -53,7 +53,6 @@ public class EffectUtil {
                hasValidSyncData();
     }
 
-    // 直接返回原版格式的activeEffects
     public static Map<Holder<MobEffect>, MobEffectInstance> getActiveEffectsMap() {
         return activeEffects;
     }

--- a/fabric/src/client/resources/spectatorplus.client.mixins.json
+++ b/fabric/src/client/resources/spectatorplus.client.mixins.json
@@ -31,7 +31,8 @@
     "screen.ImageButtonAccessor",
     "screen.InventoryMenuMixin",
     "screen.InventoryScreenMixin",
-    "screen.MenuScreensMixin"
+    "screen.MenuScreensMixin",
+    "screen.ScreenMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/fabric/src/client/resources/spectatorplus.client.mixins.json
+++ b/fabric/src/client/resources/spectatorplus.client.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "com.hpfxd.spectatorplus.fabric.client.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "client": [
     "ClientLevelAccessor",
     "ClientLevelMixin",

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/mixin/ServerGamePacketListenerImplMixin.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/mixin/ServerGamePacketListenerImplMixin.java
@@ -1,7 +1,9 @@
 package com.hpfxd.spectatorplus.fabric.mixin;
 
 import com.hpfxd.spectatorplus.fabric.sync.ServerSyncController;
+import com.hpfxd.spectatorplus.fabric.sync.handler.CursorSyncHandler;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundSelectedSlotSyncPacket;
+import net.minecraft.network.protocol.game.ServerboundContainerClickPacket;
 import net.minecraft.network.protocol.game.ServerboundSetCarriedItemPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
@@ -19,5 +21,11 @@ public abstract class ServerGamePacketListenerImplMixin {
     @Inject(method = "handleSetCarriedItem(Lnet/minecraft/network/protocol/game/ServerboundSetCarriedItemPacket;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;setSelectedSlot(I)V"))
     private void spectatorplus$syncSelectedSlot(ServerboundSetCarriedItemPacket packet, CallbackInfo ci) {
         ServerSyncController.broadcastPacketToSpectators(this.player, new ClientboundSelectedSlotSyncPacket(this.player.getUUID(), packet.getSlot()));
+    }
+
+    @Inject(method = "handleContainerClick(Lnet/minecraft/network/protocol/game/ServerboundContainerClickPacket;)V", at = @At("TAIL"))
+    private void spectatorplus$syncCursorAfterClick(ServerboundContainerClickPacket packet, CallbackInfo ci) {
+        // After handling container click, check if cursor item changed
+        CursorSyncHandler.onCursorChanged(this.player, this.player.containerMenu.getCarried(), packet.slotNum());
     }
 }

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/CustomPacketCodecs.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/CustomPacketCodecs.java
@@ -25,7 +25,7 @@ public final class CustomPacketCodecs {
         final ItemStack[] items = new ItemStack[len];
 
         for (int slot = 0; slot < len; slot++) {
-            items[slot] = buf.readBoolean() ? ItemStack.OPTIONAL_STREAM_CODEC.decode(buf) : null;
+            items[slot] = buf.readBoolean() ? CustomPacketCodecs.readItem(buf) : null;
         }
 
         return items;
@@ -37,14 +37,22 @@ public final class CustomPacketCodecs {
         for (final ItemStack item : items) {
             buf.writeBoolean(item != null);
             if (item != null) {
-                ItemStack.OPTIONAL_STREAM_CODEC.encode(buf, item);
+                CustomPacketCodecs.writeItem(buf, item);
             }
         }
     }
 
     public static ItemStack readItem(RegistryFriendlyByteBuf buf) {
         try {
-            return ItemStack.OPTIONAL_STREAM_CODEC.decode(buf);
+            int length = buf.readInt();
+            if (length == 0) {
+                return ItemStack.EMPTY;
+            }
+            byte[] bytes = new byte[length];
+            buf.readBytes(bytes);
+            java.io.ByteArrayInputStream in = new java.io.ByteArrayInputStream(bytes);
+            net.minecraft.nbt.CompoundTag tag = net.minecraft.nbt.NbtIo.readCompressed(in, net.minecraft.nbt.NbtAccounter.unlimitedHeap());
+            return ItemStack.OPTIONAL_CODEC.parse(buf.registryAccess().createSerializationContext(net.minecraft.nbt.NbtOps.INSTANCE), tag).getOrThrow(DecoderException::new);
         } catch (Exception e) {
             throw new DecoderException("Failed to read ItemStack", e);
         }
@@ -52,7 +60,20 @@ public final class CustomPacketCodecs {
 
     public static void writeItem(RegistryFriendlyByteBuf buf, @NotNull ItemStack item) {
         try {
-            ItemStack.OPTIONAL_STREAM_CODEC.encode(buf, item);
+            if (item.isEmpty()) {
+                buf.writeInt(0);
+                return;
+            }
+            net.minecraft.nbt.Tag tag = ItemStack.OPTIONAL_CODEC.encodeStart(buf.registryAccess().createSerializationContext(net.minecraft.nbt.NbtOps.INSTANCE), item).getOrThrow(EncoderException::new);
+            if (!(tag instanceof net.minecraft.nbt.CompoundTag)) {
+                buf.writeInt(0);
+                return;
+            }
+            java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+            net.minecraft.nbt.NbtIo.writeCompressed((net.minecraft.nbt.CompoundTag)tag, out);
+            byte[] bytes = out.toByteArray();
+            buf.writeInt(bytes.length);
+            buf.writeBytes(bytes);
         } catch (Exception e) {
             throw new EncoderException("Failed to write ItemStack", e);
         }

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/ServerSyncController.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/ServerSyncController.java
@@ -1,8 +1,12 @@
 package com.hpfxd.spectatorplus.fabric.sync;
 
+import com.hpfxd.spectatorplus.fabric.sync.handler.ContainerSyncHandler;
+import com.hpfxd.spectatorplus.fabric.sync.handler.CursorSyncHandler;
 import com.hpfxd.spectatorplus.fabric.sync.handler.EffectsSyncHandler;
 import com.hpfxd.spectatorplus.fabric.sync.handler.HotbarSyncHandler;
+import com.hpfxd.spectatorplus.fabric.sync.handler.InventorySyncHandler;
 import com.hpfxd.spectatorplus.fabric.sync.handler.ScreenSyncHandler;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -16,7 +20,10 @@ public class ServerSyncController {
 
         HotbarSyncHandler.init();
         ScreenSyncHandler.init();
+        ContainerSyncHandler.init();
         EffectsSyncHandler.init();
+        InventorySyncHandler.init();
+        CursorSyncHandler.init();
     }
 
     public static void sendPacket(ServerPlayer serverPlayer, ClientboundSyncPacket packet) {

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/SyncPackets.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/SyncPackets.java
@@ -1,5 +1,6 @@
 package com.hpfxd.spectatorplus.fabric.sync;
 
+import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundContainerSyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundEffectsSyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundExperienceSyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundFoodSyncPacket;
@@ -17,6 +18,7 @@ public final class SyncPackets {
         PayloadTypeRegistry.playC2S().register(ServerboundOpenedInventorySyncPacket.TYPE, ServerboundOpenedInventorySyncPacket.STREAM_CODEC);
         PayloadTypeRegistry.playC2S().register(ServerboundRequestInventoryOpenPacket.TYPE, ServerboundRequestInventoryOpenPacket.STREAM_CODEC);
 
+        PayloadTypeRegistry.playS2C().register(ClientboundContainerSyncPacket.TYPE, ClientboundContainerSyncPacket.STREAM_CODEC);
         PayloadTypeRegistry.playS2C().register(ClientboundExperienceSyncPacket.TYPE, ClientboundExperienceSyncPacket.STREAM_CODEC);
         PayloadTypeRegistry.playS2C().register(ClientboundFoodSyncPacket.TYPE, ClientboundFoodSyncPacket.STREAM_CODEC);
         PayloadTypeRegistry.playS2C().register(ClientboundHotbarSyncPacket.TYPE, ClientboundHotbarSyncPacket.STREAM_CODEC);

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/SyncPackets.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/SyncPackets.java
@@ -14,17 +14,17 @@ import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 
 public final class SyncPackets {
     public static void registerAll() {
-        PayloadTypeRegistry.playC2S().register(ServerboundOpenedInventorySyncPacket.TYPE, ServerboundOpenedInventorySyncPacket.STREAM_CODEC);
-        PayloadTypeRegistry.playC2S().register(ServerboundRequestInventoryOpenPacket.TYPE, ServerboundRequestInventoryOpenPacket.STREAM_CODEC);
+        PayloadTypeRegistry.serverboundPlay().register(ServerboundOpenedInventorySyncPacket.TYPE, ServerboundOpenedInventorySyncPacket.STREAM_CODEC);
+        PayloadTypeRegistry.serverboundPlay().register(ServerboundRequestInventoryOpenPacket.TYPE, ServerboundRequestInventoryOpenPacket.STREAM_CODEC);
 
-        PayloadTypeRegistry.playS2C().register(ClientboundExperienceSyncPacket.TYPE, ClientboundExperienceSyncPacket.STREAM_CODEC);
-        PayloadTypeRegistry.playS2C().register(ClientboundFoodSyncPacket.TYPE, ClientboundFoodSyncPacket.STREAM_CODEC);
-        PayloadTypeRegistry.playS2C().register(ClientboundHotbarSyncPacket.TYPE, ClientboundHotbarSyncPacket.STREAM_CODEC);
-        PayloadTypeRegistry.playS2C().register(ClientboundInventorySyncPacket.TYPE, ClientboundInventorySyncPacket.STREAM_CODEC);
-        PayloadTypeRegistry.playS2C().register(ClientboundScreenCursorSyncPacket.TYPE, ClientboundScreenCursorSyncPacket.STREAM_CODEC);
-        PayloadTypeRegistry.playS2C().register(ClientboundScreenSyncPacket.TYPE, ClientboundScreenSyncPacket.STREAM_CODEC);
-        PayloadTypeRegistry.playS2C().register(ClientboundSelectedSlotSyncPacket.TYPE, ClientboundSelectedSlotSyncPacket.STREAM_CODEC);
-        PayloadTypeRegistry.playS2C().register(ClientboundEffectsSyncPacket.TYPE, ClientboundEffectsSyncPacket.STREAM_CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(ClientboundExperienceSyncPacket.TYPE, ClientboundExperienceSyncPacket.STREAM_CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(ClientboundFoodSyncPacket.TYPE, ClientboundFoodSyncPacket.STREAM_CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(ClientboundHotbarSyncPacket.TYPE, ClientboundHotbarSyncPacket.STREAM_CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(ClientboundInventorySyncPacket.TYPE, ClientboundInventorySyncPacket.STREAM_CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(ClientboundScreenCursorSyncPacket.TYPE, ClientboundScreenCursorSyncPacket.STREAM_CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(ClientboundScreenSyncPacket.TYPE, ClientboundScreenSyncPacket.STREAM_CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(ClientboundSelectedSlotSyncPacket.TYPE, ClientboundSelectedSlotSyncPacket.STREAM_CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(ClientboundEffectsSyncPacket.TYPE, ClientboundEffectsSyncPacket.STREAM_CODEC);
     }
 
     private SyncPackets() {

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/ContainerSyncHandler.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/ContainerSyncHandler.java
@@ -1,0 +1,113 @@
+package com.hpfxd.spectatorplus.fabric.sync.handler;
+
+import com.hpfxd.spectatorplus.fabric.sync.ServerSyncController;
+import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundContainerSyncPacket;
+import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundScreenSyncPacket;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ContainerListener;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class ContainerSyncHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContainerSyncHandler.class);
+
+    // Map to track container listeners for each spectator
+    // Key: spectator UUID, Value: listener instance
+    private static final Map<UUID, ContainerListener> containerListeners = new HashMap<>();
+
+    public static void init() {
+        // Clean up listeners when a player disconnects
+        ServerPlayConnectionEvents.DISCONNECT.register((handler, server) -> {
+            containerListeners.remove(handler.getPlayer().getUUID());
+        });
+    }
+
+    /**
+     * Unsubscribe a spectator from a target player's container.
+     * This removes the container listener.
+     */
+    public static void unsubscribeFromContainer(ServerPlayer spectator, ServerPlayer target) {
+        target.containerMenu.removeSlotListener(containerListeners.get(spectator.getUUID()));
+
+    }
+
+    public static void sendPacket(ServerPlayer spectator, ServerPlayer target) {
+        InventorySyncHandler.sendPacket(spectator, target);
+        var containerMenu = target.containerMenu;
+        if (containerMenu == target.inventoryMenu) {
+            return; // No container open, just player inventory
+        }
+        ItemStack[] containerItems = extractContainerItems(containerMenu);
+        ServerSyncController.broadcastPacketToSpectators(target, new ClientboundContainerSyncPacket(
+            target.getUUID(),
+            containerMenu.getType(),
+            containerItems.length,
+            containerItems
+        ));
+
+        int flags = 0; // Container screen (not survival inventory)
+        flags |= (1 << 2); // Has dummy slots flag for container screens
+        ServerSyncController.broadcastPacketToSpectators(target, new ClientboundScreenSyncPacket(target.getUUID(), flags));
+
+        containerMenu.addSlotListener(createContainerListener(spectator, target));
+
+        spectator.connection.send(new ClientboundOpenScreenPacket(
+                containerMenu.containerId,
+                containerMenu.getType(),
+                target.getDisplayName()
+        ));
+    }
+
+    private static ItemStack[] extractContainerItems(AbstractContainerMenu menu) {
+        int containerSize = menu.slots.size() - 36; // Subtract player inventory slots
+        ItemStack[] containerItems = new ItemStack[containerSize];
+
+        for (int i = 0; i < containerSize; i++) {
+            var slot = menu.getSlot(i);
+            containerItems[i] = slot.getItem().copy();
+        }
+
+        return containerItems;
+    }
+
+    public static ContainerListener createContainerListener(ServerPlayer spectator, ServerPlayer target) {
+        return new ContainerListener() {
+            @Override
+            public void slotChanged(@NotNull AbstractContainerMenu menu, int slotIndex, @NotNull ItemStack stack) {
+                // Only sync container slots, not player inventory slots
+                if (slotIndex < menu.slots.size() - 36 && ServerSyncController.getSpectators(target).contains(spectator)) {
+                    ItemStack[] update = new ItemStack[menu.slots.size() - 36];
+                    for (int i = 0; i < update.length; i++) {
+                        if (i == slotIndex) {
+                            update[i] = stack.copy();
+                        } else {
+                            // For efficiency, only send changed slot
+                            update[i] = null;
+                        }
+                    }
+                    ServerSyncController.broadcastPacketToSpectators(target, new ClientboundContainerSyncPacket(
+                        target.getUUID(),
+                        menu.getType(),
+                        update.length,
+                        update
+                    ));
+                }
+            }
+
+            @Override
+            public void dataChanged(@NotNull AbstractContainerMenu menu, int dataSlot, int value) {
+                // Handle furnace progress, brewing stand progress, etc.
+                // For now, we don't need to sync this separately
+            }
+        };
+    }
+}

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/ContainerSyncHandler.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/ContainerSyncHandler.java
@@ -96,7 +96,7 @@ public class ContainerSyncHandler {
                             update[i] = null;
                         }
                     }
-                    ServerSyncController.broadcastPacketToSpectators(target, new ClientboundContainerSyncPacket(
+                    ServerSyncController.sendPacket(spectator, new ClientboundContainerSyncPacket(
                         target.getUUID(),
                         menu.getType(),
                         update.length,

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/CursorSyncHandler.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/CursorSyncHandler.java
@@ -1,0 +1,75 @@
+package com.hpfxd.spectatorplus.fabric.sync.handler;
+
+import com.hpfxd.spectatorplus.fabric.sync.ServerSyncController;
+import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundScreenCursorSyncPacket;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Handles synchronization of cursor items (items being dragged) to spectators
+ */
+public class CursorSyncHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CursorSyncHandler.class);
+    private static final Map<UUID, ItemStack> playerCursors = new HashMap<>();
+
+    public static void init() {
+        ServerPlayConnectionEvents.DISCONNECT.register((handler, server) ->
+            playerCursors.remove(handler.getPlayer().getUUID()));
+    }
+
+    /**
+     * Called when a player's cursor item changes
+     */
+    public static void onCursorChanged(ServerPlayer player, ItemStack newCursor) {
+        onCursorChanged(player, newCursor, -1);
+    }
+
+    /**
+     * Called when a player's cursor item changes
+     */
+    public static void onCursorChanged(ServerPlayer player, ItemStack newCursor, int originSlot) {
+        ItemStack oldCursor = playerCursors.get(player.getUUID());
+        if  (oldCursor == null) {
+            oldCursor = ItemStack.EMPTY;
+        }
+        if (newCursor == null) {
+            newCursor = ItemStack.EMPTY;
+        }
+
+        if (!ItemStack.isSameItem(oldCursor, newCursor)) {
+            playerCursors.put(player.getUUID(), newCursor.copy());
+
+            ClientboundScreenCursorSyncPacket packet = new ClientboundScreenCursorSyncPacket(
+                    player.getUUID(),
+                    newCursor,
+                    originSlot
+            );
+
+            ServerSyncController.broadcastPacketToSpectators(player, packet);
+        }
+    }
+
+    /**
+     * Send initial cursor data to a spectator
+     */
+    public static void sendPacket(ServerPlayer spectator, ServerPlayer target) {
+        ItemStack cursor = playerCursors.getOrDefault(target.getUUID(), ItemStack.EMPTY);
+
+        if (!cursor.isEmpty()) {
+            ClientboundScreenCursorSyncPacket packet = new ClientboundScreenCursorSyncPacket(
+                target.getUUID(),
+                cursor,
+                -1
+            );
+
+            ServerSyncController.sendPacket(spectator, packet);
+        }
+    }
+}

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/HotbarSyncHandler.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/HotbarSyncHandler.java
@@ -22,7 +22,7 @@ public class HotbarSyncHandler {
 
         ServerLifecycleEvents.SERVER_STOPPING.register(server -> HOTBARS.clear());
 
-        ServerTickEvents.END_WORLD_TICK.register(HotbarSyncHandler::tick);
+        ServerTickEvents.END_LEVEL_TICK.register(HotbarSyncHandler::tick);
     }
 
     private static void tick(ServerLevel level) {

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/InventorySyncHandler.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/InventorySyncHandler.java
@@ -56,8 +56,6 @@ public class InventorySyncHandler {
         boolean updatedHotbar = false;
         boolean updatedInventory = false;
 
-        final Inventory inventory = player.getInventory();
-
         // Main inventory (0-35) including hotbar (0-8)
         for (int i = 0; i < currentSlots.length; i++) {
             if (!ItemStack.matches(currentSlots[i], slots[i])) {
@@ -96,18 +94,18 @@ public class InventorySyncHandler {
         // Main inventory  (0-35)
         IntStream.range(0, 36).forEach(i -> {
             ItemStack item = inventory.getItem(i);
-            slots[i] = item != null ? item : ItemStack.EMPTY;
+            slots[i] = item;
         });
 
         // Armor (36-39)
         IntStream.range(36, 40).forEach(i -> {
             ItemStack item = inventory.getItem(i);
-            slots[i] = item != null ? item : ItemStack.EMPTY;
+            slots[i] = item;
         });
 
         // Offhand slot (40)
         ItemStack offhand = inventory.getItem(40);
-        slots[40] = offhand != null ? offhand : ItemStack.EMPTY;
+        slots[40] = offhand;
 
         return slots;
     }

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/InventorySyncHandler.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/InventorySyncHandler.java
@@ -1,0 +1,128 @@
+package com.hpfxd.spectatorplus.fabric.sync.handler;
+
+import com.hpfxd.spectatorplus.fabric.sync.ServerSyncController;
+import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundHotbarSyncPacket;
+import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundInventorySyncPacket;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+public class InventorySyncHandler {
+    private static final Map<UUID, ItemStack[]> playerInventories = new HashMap<>();
+    private static int tickCounter = 0;
+    private static final int SYNC_INTERVAL = 5; // Sync every 5 ticks (4 times per second)
+
+    public static void init() {
+        ServerPlayConnectionEvents.DISCONNECT.register((handler, server) ->
+            playerInventories.remove(handler.getPlayer().getUUID()));
+        ServerTickEvents.END_SERVER_TICK.register(InventorySyncHandler::tick);
+    }
+
+    public static void tick(MinecraftServer server) {
+        tickCounter++;
+        if (tickCounter % SYNC_INTERVAL != 0) {
+            return; // Skip this tick
+        }
+
+        for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+            if (ServerSyncController.getSpectators(player).isEmpty()) {
+                continue;
+            }
+            syncPlayerInventory(player);
+        }
+    }
+
+    private static void syncPlayerInventory(ServerPlayer player) {
+        final ItemStack[] slots = playerInventories.computeIfAbsent(player.getUUID(), k -> {
+            final ItemStack[] arr = new ItemStack[ClientboundInventorySyncPacket.ITEMS_LENGTH];
+            Arrays.fill(arr, ItemStack.EMPTY);
+            return arr;
+        });
+
+        //as hotbar will change more than rest of inventory, we track it separately to avoid sending full inventory when only hotbar changes
+        final ItemStack[] currentSlots = extractPlayerInventory(player);
+        final ItemStack[] inventorySendSlots = new ItemStack[ClientboundInventorySyncPacket.ITEMS_LENGTH];
+        final ItemStack[] hotbarSendSlots = new ItemStack[ClientboundHotbarSyncPacket.ITEMS_LENGTH];
+
+        boolean updatedHotbar = false;
+        boolean updatedInventory = false;
+
+        final Inventory inventory = player.getInventory();
+
+        // Main inventory (0-35) including hotbar (0-8)
+        for (int i = 0; i < currentSlots.length; i++) {
+            if (!ItemStack.matches(currentSlots[i], slots[i])) {
+                slots[i] = currentSlots[i].copy();
+                inventorySendSlots[i] = currentSlots[i];
+                updatedInventory = true;
+
+                // 热键栏是槽位 0-8
+                if (i < ClientboundHotbarSyncPacket.ITEMS_LENGTH) {
+                    hotbarSendSlots[i] = currentSlots[i];
+                    updatedHotbar = true;
+                }
+            }
+        }
+
+        if (updatedInventory) {
+            ScreenSyncHandler.updatePlayerInventory(player, inventorySendSlots);
+        }
+
+        if (updatedHotbar) {
+            ServerSyncController.broadcastPacketToSpectators(player,
+                    new ClientboundHotbarSyncPacket(player.getUUID(), hotbarSendSlots));
+        }
+    }
+
+    //this for send full inventory packet immediately
+    public static void sendPacket(ServerPlayer spectator, ServerPlayer target) {
+        final ItemStack[] slots = extractPlayerInventory(target);
+        ServerSyncController.broadcastPacketToSpectators(target, new ClientboundInventorySyncPacket(target.getUUID(), slots));
+    }
+
+    private static ItemStack[] extractPlayerInventory(ServerPlayer player) {
+        final Inventory inventory = player.getInventory();
+        final ItemStack[] slots = new ItemStack[ClientboundInventorySyncPacket.ITEMS_LENGTH];
+
+        // Main inventory  (0-35)
+        IntStream.range(0, 36).forEach(i -> {
+            ItemStack item = inventory.getItem(i);
+            slots[i] = item != null ? item : ItemStack.EMPTY;
+        });
+
+        // Armor (36-39)
+        IntStream.range(36, 40).forEach(i -> {
+            ItemStack item = inventory.getItem(i);
+            slots[i] = item != null ? item : ItemStack.EMPTY;
+        });
+
+        // Offhand slot (40)
+        ItemStack offhand = inventory.getItem(40);
+        slots[40] = offhand != null ? offhand : ItemStack.EMPTY;
+
+        return slots;
+    }
+
+    public static void onPlayerDisconnect(UUID playerId) {
+        playerInventories.remove(playerId);
+    }
+
+    /**
+     * Force an immediate inventory sync for a player, bypassing the tick counter
+     * Used for critical inventory changes that need immediate synchronization
+     */
+    public static void forceSyncPlayer(ServerPlayer player) {
+        if (!ServerSyncController.getSpectators(player).isEmpty()) {
+            syncPlayerInventory(player);
+        }
+    }
+}

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/ScreenSyncHandler.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/ScreenSyncHandler.java
@@ -5,14 +5,11 @@ import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundInventorySyncPacket
 import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundScreenSyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ServerboundOpenedInventorySyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ServerboundRequestInventoryOpenPacket;
-import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Collection;
 
 public class ScreenSyncHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(ScreenSyncHandler.class);
@@ -95,9 +92,7 @@ public class ScreenSyncHandler {
     }
 
     public static void updatePlayerInventory(ServerPlayer player, ItemStack[] inventorySendSlots) {
-        for (ServerPlayer spectator : ServerSyncController.getSpectators(player)) {
-            ServerSyncController.broadcastPacketToSpectators(player, new ClientboundInventorySyncPacket(player.getUUID(), inventorySendSlots));
-        }
+        ServerSyncController.broadcastPacketToSpectators(player, new ClientboundInventorySyncPacket(player.getUUID(), inventorySendSlots));
     }
 
     /**

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/ScreenSyncHandler.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/handler/ScreenSyncHandler.java
@@ -1,18 +1,118 @@
 package com.hpfxd.spectatorplus.fabric.sync.handler;
 
+import com.hpfxd.spectatorplus.fabric.sync.ServerSyncController;
+import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundInventorySyncPacket;
+import com.hpfxd.spectatorplus.fabric.sync.packet.ClientboundScreenSyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ServerboundOpenedInventorySyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.packet.ServerboundRequestInventoryOpenPacket;
+import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
 
 public class ScreenSyncHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScreenSyncHandler.class);
+
     public static void init() {
         ServerPlayNetworking.registerGlobalReceiver(ServerboundRequestInventoryOpenPacket.TYPE, ScreenSyncHandler::handle);
         ServerPlayNetworking.registerGlobalReceiver(ServerboundOpenedInventorySyncPacket.TYPE, ScreenSyncHandler::handle);
     }
 
     private static void handle(ServerboundRequestInventoryOpenPacket packet, ServerPlayNetworking.Context ctx) {
+        final var spectator = ctx.player();
+        final var target = ctx.server().getPlayerList().getPlayer(packet.playerId());
+        if (target == null) {
+            return;
+        }
+        // Send screen sync packet to indicate survival inventory
+        int flags = 1; // Survival inventory flag
+        flags |= (1 << 1); // Client requested flag
+        // Send full inventory data
+        InventorySyncHandler.sendPacket(spectator, target);
+
+        ServerSyncController.broadcastPacketToSpectators(target, new ClientboundScreenSyncPacket(target.getUUID(), flags));
+
     }
 
     private static void handle(ServerboundOpenedInventorySyncPacket packet, ServerPlayNetworking.Context ctx) {
+        final var player = ctx.player();
+        if (packet.isOpened()) {
+            syncScreenOpened(player);
+        } else {
+            syncScreenClosed(player);
+        }
+    }
+
+    /**
+     * Called when a player opens their inventory or any container screen.
+     * This method syncs the appropriate screen to all spectators who are viewing this player.
+     *
+     * @param target The player who opened their inventory/container
+     */
+    public static void syncScreenOpened(ServerPlayer target) {
+        var spectators = ServerSyncController.getSpectators(target);
+        if (spectators.isEmpty()) {
+            return;
+        }
+
+        for (ServerPlayer spectator : spectators) {
+            // Determine what type of screen the target player has open
+            if (target.containerMenu != target.inventoryMenu) {
+                // Player has a container open (chest, crafting table, furnace, etc.)
+                ContainerSyncHandler.sendPacket(spectator, target);
+
+            } else {
+                // Player has their regular inventory open (survival/creative inventory)
+                syncPlayerInventoryScreen(spectator, target);
+            }
+        }
+    }
+
+    /**
+     * Called when a player closes their inventory or any container screen.
+     * This method closes the synced screen for all spectators who are viewing this player.
+     *
+     * @param target The player who closed their inventory/container
+     */
+    public static void syncScreenClosed(ServerPlayer target) {
+        var spectators = ServerSyncController.getSpectators(target);
+        if (spectators.isEmpty()) {
+            return;
+        }
+
+        for (ServerPlayer spectator : spectators) {
+            ContainerSyncHandler.unsubscribeFromContainer(spectator, target);
+
+            // Send screen sync packet to indicate inventory/container was closed
+            int flags = 0; // No flags means close screen
+            flags |= (1 << 3); // Screen closed flag
+            ServerSyncController.broadcastPacketToSpectators(target, new ClientboundScreenSyncPacket(target.getUUID(), flags));
+        }
+    }
+
+    public static void updatePlayerInventory(ServerPlayer player, ItemStack[] inventorySendSlots) {
+        for (ServerPlayer spectator : ServerSyncController.getSpectators(player)) {
+            ServerSyncController.broadcastPacketToSpectators(player, new ClientboundInventorySyncPacket(player.getUUID(), inventorySendSlots));
+        }
+    }
+
+    /**
+     * Syncs a player's regular inventory screen (survival/creative inventory) to a spectator.
+     * This is used when the target player has opened their own inventory.
+     *
+     * @param spectator The spectator to sync the screen to
+     * @param target The player whose inventory screen should be synced
+     */
+    private static void syncPlayerInventoryScreen(ServerPlayer spectator, ServerPlayer target) {
+        // Send screen sync packet for player inventory (survival inventory)
+        int flags = 1; // Survival inventory flag
+        // Send the target's inventory data to the spectator
+        InventorySyncHandler.sendPacket(spectator, target);
+
+        ServerSyncController.broadcastPacketToSpectators(target, new ClientboundScreenSyncPacket(target.getUUID(), flags));
     }
 }

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/packet/ClientboundContainerSyncPacket.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/packet/ClientboundContainerSyncPacket.java
@@ -1,0 +1,58 @@
+package com.hpfxd.spectatorplus.fabric.sync.packet;
+
+import com.hpfxd.spectatorplus.fabric.sync.ClientboundSyncPacket;
+import com.hpfxd.spectatorplus.fabric.sync.CustomPacketCodecs;
+import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+public record ClientboundContainerSyncPacket(
+        UUID playerId,
+        MenuType<?> containerType,
+        int containerSize,
+        ItemStack[] items
+) implements ClientboundSyncPacket {
+    public static final StreamCodec<RegistryFriendlyByteBuf, ClientboundContainerSyncPacket> STREAM_CODEC =
+        CustomPacketPayload.codec(ClientboundContainerSyncPacket::write, ClientboundContainerSyncPacket::new);
+    public static final CustomPacketPayload.Type<ClientboundContainerSyncPacket> TYPE =
+        new CustomPacketPayload.Type<>(Identifier.parse("spectatorplus:container_sync"));
+    private static final String PERMISSION = "spectatorplus.sync.screen";
+
+    public ClientboundContainerSyncPacket(RegistryFriendlyByteBuf buf) {
+        this(
+            buf.readUUID(),
+                buf.readById(id -> {
+                    MenuType<?> type = BuiltInRegistries.MENU.byId(id);
+                    return type != null ? type : MenuType.GENERIC_9x3;
+                }),
+            buf.readVarInt(),
+            CustomPacketCodecs.readItems(buf)
+        );
+    }
+
+    public void write(RegistryFriendlyByteBuf buf) {
+        buf.writeUUID(this.playerId);
+        buf.writeById(BuiltInRegistries.MENU::getId, this.containerType);
+        buf.writeVarInt(this.containerSize);
+        CustomPacketCodecs.writeItems(buf, this.items);
+    }
+
+    @Override
+    public @NotNull Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+
+    @Override
+    public boolean canSend(ServerPlayer receiver) {
+        return Permissions.check(receiver, PERMISSION, true);
+    }
+}

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/packet/ClientboundHotbarSyncPacket.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/packet/ClientboundHotbarSyncPacket.java
@@ -20,6 +20,7 @@ public record ClientboundHotbarSyncPacket(
     public static final StreamCodec<RegistryFriendlyByteBuf, ClientboundHotbarSyncPacket> STREAM_CODEC = CustomPacketPayload.codec(ClientboundHotbarSyncPacket::write, ClientboundHotbarSyncPacket::new);
     public static final CustomPacketPayload.Type<ClientboundHotbarSyncPacket> TYPE = new CustomPacketPayload.Type<>(Identifier.parse("spectatorplus:hotbar_sync"));
     static final String PERMISSION = "spectatorplus.sync.hotbar";
+    public static final int ITEMS_LENGTH = 9;
 
     public static ClientboundHotbarSyncPacket initializing(ServerPlayer target) {
         final ItemStack[] items = new ItemStack[9];

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/packet/ClientboundScreenCursorSyncPacket.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/packet/ClientboundScreenCursorSyncPacket.java
@@ -2,6 +2,7 @@ package com.hpfxd.spectatorplus.fabric.sync.packet;
 
 import com.hpfxd.spectatorplus.fabric.sync.ClientboundSyncPacket;
 import com.hpfxd.spectatorplus.fabric.sync.CustomPacketCodecs;
+import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
@@ -19,6 +20,7 @@ public record ClientboundScreenCursorSyncPacket(
 ) implements ClientboundSyncPacket {
     public static final StreamCodec<RegistryFriendlyByteBuf, ClientboundScreenCursorSyncPacket> STREAM_CODEC = CustomPacketPayload.codec(ClientboundScreenCursorSyncPacket::write, ClientboundScreenCursorSyncPacket::new);
     public static final CustomPacketPayload.Type<ClientboundScreenCursorSyncPacket> TYPE = new CustomPacketPayload.Type<>(Identifier.parse("spectatorplus:screen_cursor_sync"));
+    private static final String PERMISSION = "spectatorplus.sync.screen";
 
     public ClientboundScreenCursorSyncPacket(RegistryFriendlyByteBuf buf) {
         this(buf.readUUID(), CustomPacketCodecs.readItem(buf), buf.readByte());
@@ -37,6 +39,6 @@ public record ClientboundScreenCursorSyncPacket(
 
     @Override
     public boolean canSend(ServerPlayer receiver) {
-        return true;
+        return Permissions.check(receiver, PERMISSION, true);
     }
 }

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/packet/ClientboundScreenSyncPacket.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/packet/ClientboundScreenSyncPacket.java
@@ -1,6 +1,7 @@
 package com.hpfxd.spectatorplus.fabric.sync.packet;
 
 import com.hpfxd.spectatorplus.fabric.sync.ClientboundSyncPacket;
+import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
@@ -16,6 +17,7 @@ public record ClientboundScreenSyncPacket(
 ) implements ClientboundSyncPacket {
     public static final StreamCodec<FriendlyByteBuf, ClientboundScreenSyncPacket> STREAM_CODEC = CustomPacketPayload.codec(ClientboundScreenSyncPacket::write, ClientboundScreenSyncPacket::new);
     public static final CustomPacketPayload.Type<ClientboundScreenSyncPacket> TYPE = new CustomPacketPayload.Type<>(Identifier.parse("spectatorplus:screen_sync"));
+    private static final String PERMISSION = "spectatorplus.sync.screen";
 
     public ClientboundScreenSyncPacket(FriendlyByteBuf buf) {
         this(buf.readUUID(), buf.readByte());
@@ -38,6 +40,10 @@ public record ClientboundScreenSyncPacket(
         return (this.flags >> 2 & 1) == 1;
     }
 
+    public boolean isScreenClosed() {
+        return (this.flags >> 3 & 1) == 1;
+    }
+
     @Override
     public @NotNull Type<? extends CustomPacketPayload> type() {
         return TYPE;
@@ -45,6 +51,6 @@ public record ClientboundScreenSyncPacket(
 
     @Override
     public boolean canSend(ServerPlayer receiver) {
-        return true;
+        return Permissions.check(receiver, PERMISSION, true);
     }
 }

--- a/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/packet/ServerboundOpenedInventorySyncPacket.java
+++ b/fabric/src/main/java/com/hpfxd/spectatorplus/fabric/sync/packet/ServerboundOpenedInventorySyncPacket.java
@@ -5,18 +5,29 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.Identifier;
-
+/*
+    * Sent by the client to the server to synchronize the opened inventory state of the player.
+ */
 public final class ServerboundOpenedInventorySyncPacket implements ServerboundSyncPacket {
     public static final StreamCodec<FriendlyByteBuf, ServerboundOpenedInventorySyncPacket> STREAM_CODEC = CustomPacketPayload.codec(ServerboundOpenedInventorySyncPacket::write, ServerboundOpenedInventorySyncPacket::new);
     public static final CustomPacketPayload.Type<ServerboundOpenedInventorySyncPacket> TYPE = new CustomPacketPayload.Type<>(Identifier.parse("spectatorplus:opened_inventory_sync"));
 
-    public ServerboundOpenedInventorySyncPacket() {
+    private final boolean isOpened;
+
+    public ServerboundOpenedInventorySyncPacket(boolean isOpened) {
+        this.isOpened = isOpened;
     }
 
     public ServerboundOpenedInventorySyncPacket(FriendlyByteBuf buf) {
+        this.isOpened = buf.readBoolean();
     }
 
     public void write(FriendlyByteBuf buf) {
+        buf.writeBoolean(this.isOpened);
+    }
+
+    public boolean isOpened() {
+        return this.isOpened;
     }
 
     @Override

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -50,14 +50,14 @@
     }
   ],
   "depends": {
-    "fabricloader": ">=0.15.0",
-    "minecraft": "~1.21.11",
-    "java": ">=21",
+    "fabricloader": ">=0.18.0",
+    "minecraft": "~26.1",
+    "java": ">=25",
     "fabric-api": "*",
     "fabric-permissions-api-v0": "*"
   },
   "suggests": {
-    "cloth-config": "^19.0.147",
-    "modmenu": "^16.0.0-rc.1"
+    "cloth-config": "*",
+    "modmenu": ">=18.0.0"
   }
 }

--- a/fabric/src/main/resources/spectatorplus.accesswidener
+++ b/fabric/src/main/resources/spectatorplus.accesswidener
@@ -1,4 +1,4 @@
-accessWidener v2 named
+accessWidener v2 official
 
 accessible class net/minecraft/server/level/ChunkMap$TrackedEntity
 
@@ -6,4 +6,4 @@ accessible class net/minecraft/client/renderer/ItemInHandRenderer$HandRenderSele
 accessible field net/minecraft/client/renderer/ItemInHandRenderer$HandRenderSelection renderMainHand Z
 accessible field net/minecraft/client/renderer/ItemInHandRenderer$HandRenderSelection renderOffHand Z
 
-accessible method net/minecraft/client/gui/Gui renderFood (Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/world/entity/player/Player;II)V
+accessible method net/minecraft/client/gui/Gui extractFood (Lnet/minecraft/client/gui/GuiGraphicsExtractor;Lnet/minecraft/world/entity/player/Player;II)V

--- a/fabric/src/main/resources/spectatorplus.mixins.json
+++ b/fabric/src/main/resources/spectatorplus.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "com.hpfxd.spectatorplus.fabric.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "mixins": [
     "ChunkMapAccessor",
     "LivingEntityMixin",

--- a/paper/gradle.properties
+++ b/paper/gradle.properties
@@ -1,2 +1,2 @@
-paper_version=1.21.11-R0.1-SNAPSHOT
+paper_version=26.1.1.build.8-alpha
 reflection_remapper_version=0.1.3

--- a/paper/src/main/java/com/hpfxd/spectatorplus/paper/sync/handler/EffectsSyncHandler.java
+++ b/paper/src/main/java/com/hpfxd/spectatorplus/paper/sync/handler/EffectsSyncHandler.java
@@ -2,6 +2,7 @@ package com.hpfxd.spectatorplus.paper.sync.handler;
 
 import com.destroystokyo.paper.event.player.PlayerStartSpectatingEntityEvent;
 import com.hpfxd.spectatorplus.paper.SpectatorPlugin;
+import com.hpfxd.spectatorplus.paper.sync.packet.ClientboundEffectsSyncPacket;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -9,61 +10,12 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import com.hpfxd.spectatorplus.paper.effect.SyncedEffect;
 
 public class EffectsSyncHandler implements Listener {
-    /**
-     * Sets the target player's potion effects to match the source player's effects.
-     * Removes all current effects and applies all effects from source.
-     */
-    private void syncPlayerEffects(Player target, Player source) {
-        java.util.Map<org.bukkit.potion.PotionEffectType, PotionEffect> sourceEffects = new java.util.HashMap<>();
-        //this.plugin.getSLF4JLogger().info("[SpectatorPlus] Syncing effects: setting {} effects to match {}: {}", target.getName(), source.getName(), sourceEffects);
-
-        for (PotionEffect effect : source.getActivePotionEffects()) {
-            sourceEffects.put(effect.getType(), effect);
-        }
-
-        java.util.Map<org.bukkit.potion.PotionEffectType, PotionEffect> targetEffects = new java.util.HashMap<>();
-        for (PotionEffect effect : target.getActivePotionEffects()) {
-            targetEffects.put(effect.getType(), effect);
-        }
-
-        // Remove effects that are not present in source or have changed
-        for (PotionEffectType type : targetEffects.keySet()) {
-            PotionEffect sourceEffect = sourceEffects.get(type);
-            PotionEffect targetEffect = targetEffects.get(type);
-            if (sourceEffect == null ||
-                sourceEffect.getDuration() != targetEffect.getDuration() ||
-                sourceEffect.getAmplifier() != targetEffect.getAmplifier() ||
-                sourceEffect.isAmbient() != targetEffect.isAmbient() ||
-                sourceEffect.hasParticles() != targetEffect.hasParticles() ||
-                sourceEffect.hasIcon() != targetEffect.hasIcon()) {
-                target.removePotionEffect(type);
-            }
-        }
-
-        // Add effects that are new or changed
-        for (PotionEffectType type : sourceEffects.keySet()) {
-            PotionEffect sourceEffect = sourceEffects.get(type);
-            PotionEffect targetEffect = targetEffects.get(type);
-            if (targetEffect == null ||
-                sourceEffect.getDuration() != targetEffect.getDuration() ||
-                sourceEffect.getAmplifier() != targetEffect.getAmplifier() ||
-                sourceEffect.isAmbient() != targetEffect.isAmbient() ||
-                sourceEffect.hasParticles() != targetEffect.hasParticles() ||
-                sourceEffect.hasIcon() != targetEffect.hasIcon()) {
-                target.addPotionEffect(new PotionEffect(
-                    sourceEffect.getType(),
-                    sourceEffect.getDuration(),
-                    sourceEffect.getAmplifier(),
-                    sourceEffect.isAmbient(),
-                    sourceEffect.hasParticles(),
-                    sourceEffect.hasIcon()
-                ));
-            }
-        }
-    }
     private static final String PERMISSION = "spectatorplus.sync.effects";
 
     private final SpectatorPlugin plugin;
@@ -73,11 +25,23 @@ public class EffectsSyncHandler implements Listener {
         Bukkit.getPluginManager().registerEvents(this, plugin);
     }
 
+    private List<SyncedEffect> getSyncedEffects(Player player) {
+        List<PotionEffect> effects = List.copyOf(player.getActivePotionEffects());
+        return effects.stream()
+                .map(pe -> new SyncedEffect(
+                        pe.getType().getKey().toString(),
+                        pe.getAmplifier(),
+                        pe.getDuration()))
+                .collect(Collectors.toList());
+    }
+
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onStartSpectatingEntity(PlayerStartSpectatingEntityEvent event) {
         final Player spectator = event.getPlayer();
         if (event.getNewSpectatorTarget() instanceof final Player target && spectator.hasPermission(PERMISSION)) {
-            syncPlayerEffects(spectator, target);
+            List<SyncedEffect> effects = getSyncedEffects(target);
+            this.plugin.getSyncController().sendPacket(spectator,
+                    new ClientboundEffectsSyncPacket(target.getUniqueId(), effects));
         }
     }
 
@@ -85,11 +49,9 @@ public class EffectsSyncHandler implements Listener {
     public void onPotionEffectChange(EntityPotionEffectEvent event) {
         if (event.getEntity() instanceof Player player) {
             Bukkit.getScheduler().runTask(this.plugin, () -> {
-                for (Player spectator : Bukkit.getOnlinePlayers()) {
-                    if (spectator != player && spectator.hasPermission(PERMISSION) && spectator.getSpectatorTarget() == player) {
-                        syncPlayerEffects(spectator, player);
-                    }
-                }
+                List<SyncedEffect> effects = getSyncedEffects(player);
+                this.plugin.getSyncController().broadcastPacketToSpectators(player, PERMISSION,
+                        new ClientboundEffectsSyncPacket(player.getUniqueId(), effects));
             });
         }
     }


### PR DESCRIPTION
This pull request introduces significant improvements to the inventory and container synchronization system for spectator clients, focusing on more robust handling of container screens, better item syncing, and clearer state management. The changes include new logic for syncing container items, improved handling of inventory open/close events, and refactoring for clarity and correctness in sync controller methods.

**Inventory and Container Synchronization Improvements:**

* Added logic to synchronize container items in all container screens, not just the player inventory, ensuring all relevant slots are updated with the correct items from the sync data. (`AbstractContainerScreenMixin.java`)
* Improved handling of container screen opening by detecting container types and sizes, and opening the appropriate synced container screen using the new `DummyContainer` class. (`MenuScreensMixin.java`, `ScreenSyncController.java`, `DummyContainer.java`) [[1]](diffhunk://#diff-befbf5e659211eac6f128cfcadae8ae019ded37f9c2909bd708168f4a22898edR53-R60) [[2]](diffhunk://#diff-a33852dd2b883ef16ba0c0282bbde84d12f1e00ad1a0db257a62cf06d08c082cR3-R31) [[3]](diffhunk://#diff-380b2b5fa30cb83919be361213bb112abca021cedf7f4b6e075e08eaf3c47434R3-R35)
* Enhanced the logic for syncing player inventory and container items by updating only the relevant slots and supporting both inventory and container screens. (`SyncedInventoryScreen.java`, `AbstractContainerScreenMixin.java`) [[1]](diffhunk://#diff-7cbddd2c366f3038ca8e5c37c6dab463d738aee9b5c9adbffea0eede1f5083d9L36-R45) [[2]](diffhunk://#diff-6afbcf8e0e1b993d579163d40cf3e1f7734de8afabc362653e4ca13996895ee2R147-R191)